### PR TITLE
Changed empty body check, deviceName and "Error Message"

### DIFF
--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -554,7 +554,7 @@ function AlexaCookie() {
                 request(options, (error, response, body) => {
                     if (!error) {
                         try {
-                            if (body != '') body = JSON.parse(body);
+                            if (typeof body !== 'object') body = JSON.parse(body);
                         } catch (err) {
                             _options.logger && _options.logger(`Get User data Response: ${JSON.stringify(body)}`);
                             callback && callback(err, null);

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -386,7 +386,7 @@ function AlexaCookie() {
                 if (!_options.proxyPort || _options.proxyPort === 0) {
                     _options.proxyPort = proxyServer.address().port;
                 }
-                const errMessage = `You can try to get the cookie manually by opening http://${_options.proxyOwnIp}:${_options.proxyPort}/ with your browser.`;
+                const errMessage = `Please open http://${_options.proxyOwnIp}:${_options.proxyPort}/ with your browser and login to Amazon. The cookie will be output here after successfull login.`;
                 callback && callback(new Error(errMessage), null);
             });
         }
@@ -442,7 +442,7 @@ function AlexaCookie() {
                 'domain': 'Device',
                 'app_version': apiCallVersion,
                 'device_type': 'A2IVLV5VM2W81',
-                'device_name': '%FIRST_NAME%\u0027s%DUPE_STRATEGY_1ST%ioBroker Alexa2',
+                'device_name': '%FIRST_NAME%\u0027s%DUPE_STRATEGY_1ST%' + _options.deviceAppName,
                 'os_version': '16.6',
                 'device_serial': deviceSerial,
                 'device_model': 'iPhone',
@@ -554,7 +554,7 @@ function AlexaCookie() {
                 request(options, (error, response, body) => {
                     if (!error) {
                         try {
-                            if (typeof body !== 'object') body = JSON.parse(body);
+                            if (body != '') body = JSON.parse(body);
                         } catch (err) {
                             _options.logger && _options.logger(`Get User data Response: ${JSON.stringify(body)}`);
                             callback && callback(err, null);

--- a/example/example.js
+++ b/example/example.js
@@ -13,7 +13,7 @@ const config = {
     userAgent: '...',          // optional: own userAgent to use for all request, overwrites default one, should not be needed
     proxyOnly: true,           // optional: should only the proxy method be used? When no email/password are provided this will set to true automatically, default: false
     setupProxy: true,          // optional: should the library setup a proxy to get cookie when automatic way did not worked? Default false!
-    proxyOwnIp: '...',         // required if proxy enabled: provide own IP or hostname to later access the proxy. needed to setup all rewriting and proxy stuff internally
+    proxyOwnIp: '...',         // required if proxy enabled: provide own IP to later access the proxy. needed to setup all rewriting and proxy stuff internally
     proxyPort: 3456,           // optional: use this port for the proxy, default is 0 means random port is selected
     proxyListenBind: '0.0.0.0',// optional: set this to bind the proxy to a special IP, default is '0.0.0.0'
     proxyLogLevel: 'info',     // optional: Loglevel of Proxy, default 'warn'


### PR DESCRIPTION
Make sure people are using an IP address instead of hostname for **proxyOwnIp**.

I noticed, my Alexa-App registrations still read **ioBroker Alexa2** although I changed the deviceName. There's a fix for this as well.

Finally, most users are confused by the Error-line asking them to open the web browser for the login session - hopefully this clears it up a little.

(in case it's relevant, I used *node v16*)