### PR TITLE
Fix Amazon login proxy auth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 logs
 *.log
 npm-debug.log*
+test-output/
 
 # Runtime data
 pids

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ node_modules
 package-lock.json
 .github
 lib/formerDataStore.json
+test-output/

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -155,8 +155,7 @@ function AlexaCookie() {
                 _options.baseAmazonPageHandle = `_${amazonDomain}`;
             }
             else if (amazonDomain !== 'com') {
-                //_options.baseAmazonPageHandle = '_' + amazonDomain;
-                _options.baseAmazonPageHandle = '';
+                _options.baseAmazonPageHandle = `_${amazonDomain}`;
             }
             else {
                 _options.baseAmazonPageHandle = '';

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -520,6 +520,7 @@ function AlexaCookie() {
             Cookie = addCookies(Cookie, response.headers);
             loginData.refreshToken = body.response.success.tokens.bearer.refresh_token;
             const accessToken = body.response.success.tokens.bearer.access_token;
+            loginData.accessToken = accessToken;
             loginData.tokenDate = Date.now();
             loginData.macDms = body.response.success.tokens.mac_dms;
 
@@ -593,7 +594,6 @@ function AlexaCookie() {
                             }
                             loginData.localCookie = resData.cookie;
                             loginData.csrf = resData.csrf;
-                            delete loginData.accessToken;
                             delete loginData.authorization_code;
                             delete loginData.verifier;
                             loginData.dataVersion = 2;
@@ -723,31 +723,38 @@ function AlexaCookie() {
 
     const finishCookieRefresh = (loginData, callback) => {
         _options.logger && _options.logger('Alexa-Cookie: Skip App registration during refresh and update local cookies');
-        const amazonPage = loginData.amazonPage || _options.amazonPage;
-        getLocalCookies(amazonPage, loginData.refreshToken, (err, localCookie) => {
-            if (err) {
-                callback && callback(err, null);
-                return;
-            }
-
-            loginData.localCookie = localCookie;
-            getCSRFFromCookies(loginData.localCookie, _options, (err, resData) => {
+        const updateLocalCookies = () => {
+            const amazonPage = loginData.amazonPage || _options.amazonPage;
+            getLocalCookies(amazonPage, loginData.refreshToken, (err, localCookie) => {
                 if (err) {
-                    callback && callback(new Error(`Error getting csrf for ${amazonPage}`), null);
+                    callback && callback(err, null);
                     return;
                 }
-                loginData.localCookie = resData.cookie;
-                loginData.csrf = resData.csrf;
-                loginData.amazonPage = amazonPage;
-                loginData.tokenDate = Date.now();
-                delete loginData.accessToken;
-                delete loginData.authorization_code;
-                delete loginData.verifier;
-                loginData.dataVersion = 2;
-                _options.logger && _options.logger('Alexa-Cookie: Refresh finished with updated cookies and csrf');
-                callback && callback(null, loginData);
+
+                loginData.localCookie = localCookie;
+                getCSRFFromCookies(loginData.localCookie, _options, (err, resData) => {
+                    if (err) {
+                        callback && callback(new Error(`Error getting csrf for ${amazonPage}`), null);
+                        return;
+                    }
+                    loginData.localCookie = resData.cookie;
+                    loginData.csrf = resData.csrf;
+                    loginData.amazonPage = amazonPage;
+                    loginData.tokenDate = Date.now();
+                    delete loginData.authorization_code;
+                    delete loginData.verifier;
+                    loginData.dataVersion = 2;
+                    _options.logger && _options.logger('Alexa-Cookie: Refresh finished with updated cookies and csrf');
+                    callback && callback(null, loginData);
+                });
             });
-        });
+        };
+
+        if (loginData.accessToken) {
+            registerTokenCapabilities(loginData.accessToken, updateLocalCookies);
+            return;
+        }
+        updateLocalCookies();
     };
 
     this.refreshAlexaCookie = (__options, callback) => {

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -39,6 +39,19 @@ function AlexaCookie() {
 
     let Cookie = '';
 
+    const isAmazonCookieName = name => /^(session-id|session-id-time|session-token|ubid-.+|lc-.+|x-.+|at-.+|sess-at-.+|frc|map-md|csrf|sid|csm-hit|i18n-prefs|sp-cdn|skin)$/.test(name);
+
+    const sanitizeAmazonCookie = cookie => {
+        const cookies = cookieTools.parse(cookie || '');
+        let sanitizedCookie = '';
+        for (const name of Object.keys(cookies)) {
+            if (isAmazonCookieName(name)) {
+                sanitizedCookie += `${name}=${cookies[name]}; `;
+            }
+        }
+        return sanitizedCookie.replace(/[; ]*$/, '');
+    };
+
     const addCookies = (Cookie, headers) => {
         if (!headers || !headers['set-cookie']) return Cookie;
         const cookies = cookieTools.parse(Cookie || '');
@@ -407,6 +420,7 @@ function AlexaCookie() {
         _options.logger && _options.logger(`Handle token registration Start: ${JSON.stringify(loginData)}`);
 
         loginData.deviceAppName = _options.deviceAppName;
+        loginData.loginCookie = sanitizeAmazonCookie(loginData.loginCookie);
 
         let deviceSerial;
         if (!_options.formerRegistrationData || !_options.formerRegistrationData.deviceSerial) {
@@ -553,22 +567,34 @@ function AlexaCookie() {
                 _options.logger && _options.logger(JSON.stringify(options));
                 request(options, (error, response, body) => {
                     if (!error) {
-                        try {
-                            if (typeof body !== 'object') body = JSON.parse(body);
-                        } catch (err) {
+                        if (!response || response.statusCode < 200 || response.statusCode >= 300 || !body) {
+                            _options.logger && _options.logger(`Get User data Response: status=${response && response.statusCode}, body=${JSON.stringify(body)}`);
+                            if (!_options.amazonPage) {
+                                callback && callback(new Error(`Could not get user data from Amazon: HTTP ${response && response.statusCode}`), null);
+                                return;
+                            }
+                            loginData.amazonPage = _options.amazonPage;
+                        } else {
+                            try {
+                                if (typeof body !== 'object') body = JSON.parse(body);
+                            } catch (err) {
+                                _options.logger && _options.logger(`Get User data Response: ${JSON.stringify(body)}`);
+                                if (!_options.amazonPage) {
+                                    callback && callback(err, null);
+                                    return;
+                                }
+                                loginData.amazonPage = _options.amazonPage;
+                            }
                             _options.logger && _options.logger(`Get User data Response: ${JSON.stringify(body)}`);
-                            callback && callback(err, null);
-                            return;
-                        }
-                        _options.logger && _options.logger(`Get User data Response: ${JSON.stringify(body)}`);
 
-                        Cookie = addCookies(Cookie, response.headers);
+                            Cookie = addCookies(Cookie, response.headers);
 
-                        if (body.marketPlaceDomainName) {
-                            const pos = body.marketPlaceDomainName.indexOf('.');
-                            if (pos !== -1) _options.amazonPage = body.marketPlaceDomainName.substr(pos + 1);
+                            if (body && body.marketPlaceDomainName) {
+                                const pos = body.marketPlaceDomainName.indexOf('.');
+                                if (pos !== -1) _options.amazonPage = body.marketPlaceDomainName.substr(pos + 1);
+                            }
+                            loginData.amazonPage = _options.amazonPage;
                         }
-                        loginData.amazonPage = _options.amazonPage;
                     } else if (error && (!_options || !_options.amazonPage)) {
                         callback && callback(error, null);
                         return;
@@ -583,6 +609,7 @@ function AlexaCookie() {
                     getLocalCookies(loginData.amazonPage, loginData.refreshToken, (err, localCookie) => {
                         if (err) {
                             callback && callback(err, null);
+                            return;
                         }
 
                         loginData.localCookie = localCookie;
@@ -842,7 +869,7 @@ function AlexaCookie() {
                 newCookie += `map-md=${initCookies['map-md']}; `;
                 newCookie += comCookie;
 
-                _options.formerRegistrationData.loginCookie = newCookie;
+                _options.formerRegistrationData.loginCookie = sanitizeAmazonCookie(newCookie);
                 finishCookieRefresh(_options.formerRegistrationData, callback);
             });
         });

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -721,6 +721,35 @@ function AlexaCookie() {
         });
     };
 
+    const finishCookieRefresh = (loginData, callback) => {
+        _options.logger && _options.logger('Alexa-Cookie: Skip App registration during refresh and update local cookies');
+        const amazonPage = loginData.amazonPage || _options.amazonPage;
+        getLocalCookies(amazonPage, loginData.refreshToken, (err, localCookie) => {
+            if (err) {
+                callback && callback(err, null);
+                return;
+            }
+
+            loginData.localCookie = localCookie;
+            getCSRFFromCookies(loginData.localCookie, _options, (err, resData) => {
+                if (err) {
+                    callback && callback(new Error(`Error getting csrf for ${amazonPage}`), null);
+                    return;
+                }
+                loginData.localCookie = resData.cookie;
+                loginData.csrf = resData.csrf;
+                loginData.amazonPage = amazonPage;
+                loginData.tokenDate = Date.now();
+                delete loginData.accessToken;
+                delete loginData.authorization_code;
+                delete loginData.verifier;
+                loginData.dataVersion = 2;
+                _options.logger && _options.logger('Alexa-Cookie: Refresh finished with updated cookies and csrf');
+                callback && callback(null, loginData);
+            });
+        });
+    };
+
     this.refreshAlexaCookie = (__options, callback) => {
         if (!__options || !__options.formerRegistrationData || !__options.formerRegistrationData.loginCookie || !__options.formerRegistrationData.refreshToken) {
             callback && callback(new Error('No former registration data provided for Cookie Refresh'), null);
@@ -798,6 +827,7 @@ function AlexaCookie() {
             getLocalCookies(_options.baseAmazonPage, _options.formerRegistrationData.refreshToken, (err, comCookie) => {
                 if (err) {
                     callback && callback(err, null);
+                    return;
                 }
 
                 // Restore frc and map-md
@@ -807,7 +837,7 @@ function AlexaCookie() {
                 newCookie += comCookie;
 
                 _options.formerRegistrationData.loginCookie = newCookie;
-                handleTokenRegistration(_options, _options.formerRegistrationData, callback);
+                finishCookieRefresh(_options.formerRegistrationData, callback);
             });
         });
     };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -247,7 +247,8 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             if (url === '/') { // initial redirect
                 returnedInitUrl =  buildInitialUrl();
                 _options.logger && _options.logger(`Alexa-Cookie: Initial Page Request: ${returnedInitUrl}`);
-                return returnedInitUrl;
+                const parsedInitUrl = new URL(returnedInitUrl);
+                return `${parsedInitUrl.protocol}//${parsedInitUrl.host}`;
             }
             else {
                 return `https://${defaultAmazonHost}`;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -177,13 +177,31 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
     const code_challenge = base64URLEncode(sha256(code_verifier));
 
     let proxyCookies = '';
+    let returnedInitUrl;
+
+    function buildInitialUrl() {
+        return `https://www.${_options.baseAmazonPage}/ap/signin?openid.return_to=https%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fmaplanding&openid.assoc_handle=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&pageId=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&accountStatusPolicy=P1&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns.oa2=http%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fext%2Foauth%2F2&openid.oa2.client_id=device%3A${deviceId}&openid.ns.pape=http%3A%2F%2Fspecs.openid.net%2Fextensions%2Fpape%2F1.0&openid.oa2.response_type=code&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.pape.max_auth_age=0&openid.oa2.scope=device_auth_access&openid.oa2.code_challenge_method=S256&openid.oa2.code_challenge=${code_challenge}&language=${_options.amazonPageProxyLanguage}`;
+    }
+
+    function rewriteProxyPath(url, req) {
+        const urlHost = amazonHostFromProxyPath(url);
+        if (urlHost) {
+            return url.replace(new RegExp(`^/${escapeRegex(urlHost)}`), '') || '/';
+        }
+        if (req && req.headers && req.headers.host === `${_options.proxyOwnIp}:${_options.proxyPort}` && url === '/') {
+            const initialUrl = returnedInitUrl || buildInitialUrl();
+            const parsed = new URL(initialUrl);
+            return `${parsed.pathname}${parsed.search}`;
+        }
+        return url;
+    }
 
     // proxy middleware options
     const optionsAlexa = {
         target: `https://alexa.${_options.baseAmazonPage}`,
         changeOrigin: true,
         ws: false,
-        pathRewrite: {}, // enhanced below
+        pathRewrite: rewriteProxyPath,
         router: router,
         hostRewrite: true,
         followRedirects: false,
@@ -199,7 +217,6 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         }
     };
     for (const host of amazonProxyHosts) {
-        optionsAlexa.pathRewrite[`^/${escapeRegex(host)}`] = '';
         const rootHost = amazonRootFromHost(host);
         optionsAlexa.cookieDomainRewrite[`.${rootHost}`] = _options.proxyOwnIp;
         optionsAlexa.cookieDomainRewrite[rootHost] = _options.proxyOwnIp;
@@ -214,7 +231,6 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             error: _options.logger.error || _options.logger
         };
     };
-    let returnedInitUrl;
 
     function router(req) {
         const url = (req.originalUrl || req.url);
@@ -229,7 +245,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
                 return `https://${refererHost}`;
             }
             if (url === '/') { // initial redirect
-                returnedInitUrl =  `https://www.${_options.baseAmazonPage}/ap/signin?openid.return_to=https%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fmaplanding&openid.assoc_handle=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&pageId=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&accountStatusPolicy=P1&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns.oa2=http%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fext%2Foauth%2F2&openid.oa2.client_id=device%3A${deviceId}&openid.ns.pape=http%3A%2F%2Fspecs.openid.net%2Fextensions%2Fpape%2F1.0&openid.oa2.response_type=code&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.pape.max_auth_age=0&openid.oa2.scope=device_auth_access&openid.oa2.code_challenge_method=S256&openid.oa2.code_challenge=${code_challenge}&language=${_options.amazonPageProxyLanguage}`;
+                returnedInitUrl =  buildInitialUrl();
                 _options.logger && _options.logger(`Alexa-Cookie: Initial Page Request: ${returnedInitUrl}`);
                 return returnedInitUrl;
             }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -36,6 +36,21 @@ function addCookies(Cookie, headers) {
     return Cookie;
 }
 
+function isAmazonCookieName(name) {
+    return /^(session-id|session-id-time|session-token|ubid-.+|lc-.+|x-.+|at-.+|sess-at-.+|frc|map-md|csrf|sid|csm-hit|i18n-prefs|sp-cdn|skin)$/.test(name);
+}
+
+function sanitizeAmazonCookie(cookie) {
+    const cookies = cookieTools.parse(cookie || '');
+    let sanitizedCookie = '';
+    for (const name of Object.keys(cookies)) {
+        if (isAmazonCookieName(name)) {
+            sanitizedCookie += `${name}=${cookies[name]}; `;
+        }
+    }
+    return sanitizedCookie.replace(/[; ]*$/, '');
+}
+
 function customStringify(v, func, intent) {
     const cache = new Map();
     return JSON.stringify(v, function (key, value) {
@@ -400,7 +415,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             _options.logger && _options.logger(`Alexa-Cookie: Proxy catched parameters: ${JSON.stringify(queryParams)}`);
 
             callbackCookie && callbackCookie(null, {
-                'loginCookie': proxyCookies,
+                'loginCookie': sanitizeAmazonCookie(proxyCookies),
                 'authorization_code': queryParams['openid.oa2.authorization_code'],
                 'frc': initialCookies.frc,
                 'map-md': initialCookies['map-md'],

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -15,6 +15,7 @@ const path = require('path');
 const crypto = require('crypto');
 
 const FORMERDATA_STORE_VERSION = 4;
+const ALEXA_APP_VERSION = '2.2.651540.0';
 
 function addCookies(Cookie, headers) {
     if (!headers || !headers['set-cookie']) return Cookie;
@@ -90,7 +91,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
     }
 
     if (!_options.formerRegistrationData || !_options.formerRegistrationData['map-md']) {
-        initialCookies['map-md'] = Buffer.from('{"device_user_dictionary":[],"device_registration_data":{"software_version":"1"},"app_identifier":{"app_version":"2.2.485407","bundle_id":"com.amazon.echo"}}').toString('base64');
+        initialCookies['map-md'] = Buffer.from(`{"device_user_dictionary":[],"device_registration_data":{"software_version":"1"},"app_identifier":{"app_version":"${ALEXA_APP_VERSION}","bundle_id":"com.amazon.echo"}}`).toString('base64');
     }
     else {
         _options.logger && _options.logger('Proxy Init: reuse map-md from former data');
@@ -150,9 +151,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         onProxyRes: onProxyRes,
         onProxyReq: onProxyReq,
         headers: {
-            'user-agent': 'AppleWebKit PitanguiBridge/2.2.485407.0-[HARDWARE=iPhone10_4][SOFTWARE=15.5][DEVICE=iPhone]',
-            'accept-language': _options.acceptLanguage,
-            'authority': `www.${_options.baseAmazonPage}`
+            'accept-language': _options.acceptLanguage
         },
         cookieDomainRewrite: { // enhanced below
             '*': ''
@@ -224,12 +223,16 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
     }
 
     function replaceHostsBack(data) {
+        const proxyBase = `http://${_options.proxyOwnIp}:${_options.proxyPort}/`;
         const amazonRegex = new RegExp(`http://${_options.proxyOwnIp}:${_options.proxyPort}/www.${_options.baseAmazonPage}/`.replace(/\./g, '\\.'), 'g');
         const alexaRegex = new RegExp(`http://${_options.proxyOwnIp}:${_options.proxyPort}/alexa.${_options.baseAmazonPage}/`.replace(/\./g, '\\.'), 'g');
         data = data.replace(amazonRegex, `https://www.${_options.baseAmazonPage}/`);
         data = data.replace(alexaRegex, `https://alexa.${_options.baseAmazonPage}/`);
-        if (data === `http://${_options.proxyOwnIp}:${_options.proxyPort}/`) {
+        if (data === proxyBase) {
             data = returnedInitUrl;
+        }
+        else if (data.startsWith(proxyBase)) {
+            data = `https://www.${_options.baseAmazonPage}/${data.slice(proxyBase.length)}`;
         }
         return data;
     }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -16,6 +16,7 @@ const crypto = require('crypto');
 
 const FORMERDATA_STORE_VERSION = 4;
 const ALEXA_APP_VERSION = '2.2.651540.0';
+const EXTRA_AMAZON_PROXY_HOSTS = ['amazon.com', 'www.amazon.com', 'alexa.amazon.com'];
 
 function addCookies(Cookie, headers) {
     if (!headers || !headers['set-cookie']) return Cookie;
@@ -56,6 +57,46 @@ function customStringify(v, func, intent) {
 
 function initAmazonProxy(_options, callbackCookie, callbackListening) {
     const initialCookies = {};
+    const proxyBase = `http://${_options.proxyOwnIp}:${_options.proxyPort}/`;
+    const defaultAmazonHost = `www.${_options.baseAmazonPage}`;
+    const amazonProxyHosts = [];
+
+    function escapeRegex(data) {
+        return data.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    function addAmazonProxyHost(host) {
+        if (host && !amazonProxyHosts.includes(host)) {
+            amazonProxyHosts.push(host);
+        }
+    }
+
+    function amazonRootFromHost(host) {
+        return host.replace(/^(www|alexa)\./, '');
+    }
+
+    addAmazonProxyHost(defaultAmazonHost);
+    addAmazonProxyHost(`alexa.${_options.baseAmazonPage}`);
+    addAmazonProxyHost(_options.baseAmazonPage);
+    EXTRA_AMAZON_PROXY_HOSTS.forEach(addAmazonProxyHost);
+
+    function amazonHostFromProxyPath(url) {
+        const match = (url || '').match(/^\/([^/?#]+)(?:[/?#]|$)/);
+        if (match && amazonProxyHosts.includes(match[1])) {
+            return match[1];
+        }
+        return null;
+    }
+
+    function amazonHostFromProxyUrl(url) {
+        if (!url) return null;
+        for (const host of amazonProxyHosts) {
+            if (url === `${proxyBase}${host}` || url.startsWith(`${proxyBase}${host}/`)) {
+                return host;
+            }
+        }
+        return null;
+    }
 
     const formerDataStorePath = _options.formerDataStorePath || path.join(__dirname, 'formerDataStore.json');
     let formerDataStoreValid = false;
@@ -157,10 +198,13 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             '*': ''
         }
     };
-    optionsAlexa.pathRewrite[`^/www.${_options.baseAmazonPage}`] = '';
-    optionsAlexa.pathRewrite[`^/alexa.${_options.baseAmazonPage}`] = '';
-    optionsAlexa.cookieDomainRewrite[`.${_options.baseAmazonPage}`] = _options.proxyOwnIp;
-    optionsAlexa.cookieDomainRewrite[_options.baseAmazonPage] = _options.proxyOwnIp;
+    for (const host of amazonProxyHosts) {
+        optionsAlexa.pathRewrite[`^/${escapeRegex(host)}`] = '';
+        const rootHost = amazonRootFromHost(host);
+        optionsAlexa.cookieDomainRewrite[`.${rootHost}`] = _options.proxyOwnIp;
+        optionsAlexa.cookieDomainRewrite[rootHost] = _options.proxyOwnIp;
+        optionsAlexa.cookieDomainRewrite[host] = _options.proxyOwnIp;
+    }
     if (_options.logger) optionsAlexa.logProvider = function logProvider() {
         return {
             log: _options.logger.log || _options.logger,
@@ -176,16 +220,13 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         const url = (req.originalUrl || req.url);
         _options.logger && _options.logger(`Router: ${url} / ${req.method} / ${JSON.stringify(req.headers)}`);
         if (req.headers.host === `${_options.proxyOwnIp}:${_options.proxyPort}`) {
-            if (url.startsWith(`/www.${_options.baseAmazonPage}/`)) {
-                return `https://www.${_options.baseAmazonPage}`;
-            } else if (url.startsWith(`/alexa.${_options.baseAmazonPage}/`)) {
-                return `https://alexa.${_options.baseAmazonPage}`;
-            } else if (req.headers.referer) {
-                if (req.headers.referer.startsWith(`http://${_options.proxyOwnIp}:${_options.proxyPort}/www.${_options.baseAmazonPage}/`)) {
-                    return `https://www.${_options.baseAmazonPage}`;
-                } else if (req.headers.referer.startsWith(`http://${_options.proxyOwnIp}:${_options.proxyPort}/alexa.${_options.baseAmazonPage}/`)) {
-                    return `https://alexa.${_options.baseAmazonPage}`;
-                }
+            const urlHost = amazonHostFromProxyPath(url);
+            if (urlHost) {
+                return `https://${urlHost}`;
+            }
+            const refererHost = amazonHostFromProxyUrl(req.headers.referer);
+            if (refererHost) {
+                return `https://${refererHost}`;
             }
             if (url === '/') { // initial redirect
                 returnedInitUrl =  `https://www.${_options.baseAmazonPage}/ap/signin?openid.return_to=https%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fmaplanding&openid.assoc_handle=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&pageId=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&accountStatusPolicy=P1&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns.oa2=http%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fext%2Foauth%2F2&openid.oa2.client_id=device%3A${deviceId}&openid.ns.pape=http%3A%2F%2Fspecs.openid.net%2Fextensions%2Fpape%2F1.0&openid.oa2.response_type=code&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.pape.max_auth_age=0&openid.oa2.scope=device_auth_access&openid.oa2.code_challenge_method=S256&openid.oa2.code_challenge=${code_challenge}&language=${_options.amazonPageProxyLanguage}`;
@@ -193,7 +234,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
                 return returnedInitUrl;
             }
             else {
-                return `https://www.${_options.baseAmazonPage}`;
+                return `https://${defaultAmazonHost}`;
             }
         }
         return `https://alexa.${_options.baseAmazonPage}`;
@@ -213,26 +254,25 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
 
     function replaceHosts(data) {
         //const dataOrig = data;
-        const amazonRegex = new RegExp(`https?://www.${_options.baseAmazonPage}:?[0-9]*/`.replace(/\./g, '\\.'), 'g');
-        const alexaRegex = new RegExp(`https?://alexa.${_options.baseAmazonPage}:?[0-9]*/`.replace(/\./g, '\\.'), 'g');
         data = data.replace(/&#x2F;/g, '/');
-        data = data.replace(amazonRegex, `http://${_options.proxyOwnIp}:${_options.proxyPort}/www.${_options.baseAmazonPage}/`);
-        data = data.replace(alexaRegex, `http://${_options.proxyOwnIp}:${_options.proxyPort}/alexa.${_options.baseAmazonPage}/`);
+        for (const host of amazonProxyHosts) {
+            const hostRegex = new RegExp(`https?://${escapeRegex(host)}:?[0-9]*/`, 'g');
+            data = data.replace(hostRegex, `${proxyBase}${host}/`);
+        }
         //_options.logger && _options.logger('REPLACEHOSTS: ' + dataOrig + ' --> ' + data);
         return data;
     }
 
     function replaceHostsBack(data) {
-        const proxyBase = `http://${_options.proxyOwnIp}:${_options.proxyPort}/`;
-        const amazonRegex = new RegExp(`http://${_options.proxyOwnIp}:${_options.proxyPort}/www.${_options.baseAmazonPage}/`.replace(/\./g, '\\.'), 'g');
-        const alexaRegex = new RegExp(`http://${_options.proxyOwnIp}:${_options.proxyPort}/alexa.${_options.baseAmazonPage}/`.replace(/\./g, '\\.'), 'g');
-        data = data.replace(amazonRegex, `https://www.${_options.baseAmazonPage}/`);
-        data = data.replace(alexaRegex, `https://alexa.${_options.baseAmazonPage}/`);
+        for (const host of amazonProxyHosts) {
+            const hostRegex = new RegExp(`${escapeRegex(proxyBase)}${escapeRegex(host)}/`, 'g');
+            data = data.replace(hostRegex, `https://${host}/`);
+        }
         if (data === proxyBase) {
             data = returnedInitUrl;
         }
         else if (data.startsWith(proxyBase)) {
-            data = `https://www.${_options.baseAmazonPage}/${data.slice(proxyBase.length)}`;
+            data = `https://${defaultAmazonHost}/${data.slice(proxyBase.length)}`;
         }
         return data;
     }
@@ -279,8 +319,8 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
                 }
             }
             if (typeof proxyReq.getHeader === 'function' && proxyReq.getHeader('origin') !== `https://${proxyReq.getHeader('host')}`) {
-                proxyReq.setHeader('origin', `https://www.${_options.baseAmazonPage}`);
-                _options.logger && _options.logger('Alexa-Cookie: Modify headers: Delete Origin');
+                proxyReq.setHeader('origin', `https://${proxyReq.getHeader('host') || defaultAmazonHost}`);
+                _options.logger && _options.logger('Alexa-Cookie: Modify headers: Changed Origin');
                 modified = true;
             }
 
@@ -314,7 +354,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         _options.logger && _options.logger(`Alexa-Cookie: Cookies handled: ${JSON.stringify(proxyCookies)}`);
 
         if (
-            (proxyRes.socket && proxyRes.socket._host === `www.${_options.baseAmazonPage}` && proxyRes.socket.parser.outgoing && proxyRes.socket.parser.outgoing.method === 'GET' && proxyRes.socket.parser.outgoing.path.startsWith('/ap/maplanding')) ||
+            (proxyRes.socket && amazonProxyHosts.includes(proxyRes.socket._host) && proxyRes.socket.parser.outgoing && proxyRes.socket.parser.outgoing.method === 'GET' && proxyRes.socket.parser.outgoing.path.startsWith('/ap/maplanding')) ||
             (proxyRes.socket && proxyRes.socket.parser.outgoing && proxyRes.socket.parser.outgoing.getHeader('location') && proxyRes.socket.parser.outgoing.getHeader('location').includes('/ap/maplanding?')) ||
             (proxyRes.headers.location && (proxyRes.headers.location.includes('/ap/maplanding?') || proxyRes.headers.location.includes('/spa/index.html')))
         ) {
@@ -345,7 +385,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         if (proxyRes.headers.location) {
             _options.logger && _options.logger(`Redirect: Original Location ----> ${proxyRes.headers.location}`);
             proxyRes.headers.location = replaceHosts(proxyRes.headers.location);
-            if (reqestHost && proxyRes.headers.location.startsWith('/')) {
+            if (reqestHost && amazonProxyHosts.includes(reqestHost) && proxyRes.headers.location.startsWith('/')) {
                 proxyRes.headers.location = `http://${_options.proxyOwnIp}:${_options.proxyPort}/${reqestHost}${proxyRes.headers.location}`;
             }
             _options.logger && _options.logger(`Redirect: Final Location ----> ${proxyRes.headers.location}`);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -277,6 +277,19 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         return data;
     }
 
+    function parseQueryParams(data) {
+        const paramStart = data && data.indexOf('?');
+        if (paramStart === -1 || paramStart === undefined) return {};
+        return querystring.parse(data.substr(paramStart + 1));
+    }
+
+    function isProxySuccessUrl(data) {
+        if (!data) return false;
+        if (data.includes('/spa/index.html')) return true;
+        if (!data.includes('/ap/maplanding?')) return false;
+        return !!parseQueryParams(data)['openid.oa2.authorization_code'];
+    }
+
     function onProxyReq(proxyReq, req/*, _res*/) {
         const url = req.originalUrl || req.url;
         if (url.endsWith('.ico') || url.endsWith('.js') || url.endsWith('.ttf') || url.endsWith('.svg') || url.endsWith('.png') || url.endsWith('.appcache')) return;
@@ -353,15 +366,17 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         }
         _options.logger && _options.logger(`Alexa-Cookie: Cookies handled: ${JSON.stringify(proxyCookies)}`);
 
-        if (
-            (proxyRes.socket && amazonProxyHosts.includes(proxyRes.socket._host) && proxyRes.socket.parser.outgoing && proxyRes.socket.parser.outgoing.method === 'GET' && proxyRes.socket.parser.outgoing.path.startsWith('/ap/maplanding')) ||
-            (proxyRes.socket && proxyRes.socket.parser.outgoing && proxyRes.socket.parser.outgoing.getHeader('location') && proxyRes.socket.parser.outgoing.getHeader('location').includes('/ap/maplanding?')) ||
-            (proxyRes.headers.location && (proxyRes.headers.location.includes('/ap/maplanding?') || proxyRes.headers.location.includes('/spa/index.html')))
-        ) {
+        const outgoing = proxyRes.socket && proxyRes.socket.parser && proxyRes.socket.parser.outgoing;
+        const successUrl = [
+            proxyRes.headers.location,
+            outgoing && outgoing.method === 'GET' && outgoing.path,
+            outgoing && outgoing.getHeader && outgoing.getHeader('location')
+        ].find(isProxySuccessUrl);
+
+        if (successUrl) {
             _options.logger && _options.logger('Alexa-Cookie: Proxy detected SUCCESS!!');
 
-            const paramStart = proxyRes.headers.location.indexOf('?');
-            const queryParams = querystring.parse(proxyRes.headers.location.substr(paramStart + 1));
+            const queryParams = parseQueryParams(successUrl);
 
             proxyRes.statusCode = 302;
             proxyRes.headers.location = `http://${_options.proxyOwnIp}:${_options.proxyPort}/cookie-success`;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -212,16 +212,13 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         headers: {
             'accept-language': _options.acceptLanguage
         },
-        cookieDomainRewrite: { // enhanced below
+        cookieDomainRewrite: {
             '*': ''
+        },
+        cookiePathRewrite: {
+            '*': '/'
         }
     };
-    for (const host of amazonProxyHosts) {
-        const rootHost = amazonRootFromHost(host);
-        optionsAlexa.cookieDomainRewrite[`.${rootHost}`] = _options.proxyOwnIp;
-        optionsAlexa.cookieDomainRewrite[rootHost] = _options.proxyOwnIp;
-        optionsAlexa.cookieDomainRewrite[host] = _options.proxyOwnIp;
-    }
     if (_options.logger) optionsAlexa.logProvider = function logProvider() {
         return {
             log: _options.logger.log || _options.logger,

--- a/test/base-amazon-page-handle.test.js
+++ b/test/base-amazon-page-handle.test.js
@@ -3,6 +3,31 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
+const testName = 'base-amazon-page-handle';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
 const cookieFile = path.join(__dirname, '..', 'alexa-cookie.js');
 const source = fs.readFileSync(cookieFile, 'utf8');
 
@@ -40,18 +65,59 @@ function loadCookieModule() {
 
 function runProxyOnlyConfig(baseAmazonPage) {
     const cookieModule = loadCookieModule();
-    cookieModule.generateAlexaCookie('', '', {
-        proxyOwnIp: '192.168.0.35',
+    const input = {
+        proxyOwnIp: '127.0.0.1',
         proxyPort: 3456,
         baseAmazonPage,
         amazonPage: baseAmazonPage,
         logger: () => {}
-    }, () => {});
-    return capturedProxyOptions;
+    };
+    cookieModule.generateAlexaCookie('', '', input, () => {});
+    return { input, output: capturedProxyOptions };
 }
 
-const deOptions = runProxyOnlyConfig('amazon.de');
-assert.strictEqual(deOptions.baseAmazonPageHandle, '_de');
+try {
+    const de = runProxyOnlyConfig('amazon.de');
+    const uk = runProxyOnlyConfig('amazon.co.uk');
+    const com = runProxyOnlyConfig('amazon.com');
 
-const comOptions = runProxyOnlyConfig('amazon.com');
-assert.strictEqual(comOptions.baseAmazonPageHandle, '');
+    line('TEST: base Amazon page handle');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- alexa-cookie.js: generateAlexaCookie option initialization');
+    line('- option passed to lib/proxy.js: baseAmazonPageHandle');
+    line('');
+    line('INPUT:');
+    line(`DE baseAmazonPage: ${de.input.baseAmazonPage}`);
+    line(`DE amazonPage: ${de.input.amazonPage}`);
+    line(`UK baseAmazonPage: ${uk.input.baseAmazonPage}`);
+    line(`UK amazonPage: ${uk.input.amazonPage}`);
+    line(`COM baseAmazonPage: ${com.input.baseAmazonPage}`);
+    line(`COM amazonPage: ${com.input.amazonPage}`);
+    line('');
+    line('OBSERVED:');
+    line(`DE baseAmazonPageHandle: ${de.output.baseAmazonPageHandle}`);
+    line(`UK baseAmazonPageHandle: ${uk.output.baseAmazonPageHandle}`);
+    line(`COM baseAmazonPageHandle: ${com.output.baseAmazonPageHandle}`);
+    line('');
+    line('ASSERTIONS:');
+    recordAssertion('DE baseAmazonPageHandle === "_de"', () => {
+        assert.strictEqual(de.output.baseAmazonPageHandle, '_de');
+    });
+    recordAssertion('UK baseAmazonPageHandle === "_uk"', () => {
+        assert.strictEqual(uk.output.baseAmazonPageHandle, '_uk');
+    });
+    recordAssertion('COM baseAmazonPageHandle === ""', () => {
+        assert.strictEqual(com.output.baseAmazonPageHandle, '');
+    });
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+}

--- a/test/base-amazon-page-handle.test.js
+++ b/test/base-amazon-page-handle.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const cookieFile = path.join(__dirname, '..', 'alexa-cookie.js');
+const source = fs.readFileSync(cookieFile, 'utf8');
+
+let capturedProxyOptions;
+
+function loadCookieModule() {
+    capturedProxyOptions = undefined;
+    const module = { exports: {} };
+    const sandbox = {
+        __dirname: path.dirname(cookieFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === './lib/proxy.js') {
+                return {
+                    initAmazonProxy(options, _callbackCookie, callbackListening) {
+                        capturedProxyOptions = options;
+                        callbackListening && callbackListening({
+                            address: () => ({ port: options.proxyPort || 3456 }),
+                            close: (callback) => callback && callback()
+                        });
+                    }
+                };
+            }
+            if (name === 'cookie') {
+                return { parse: () => ({}) };
+            }
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: cookieFile });
+    return module.exports;
+}
+
+function runProxyOnlyConfig(baseAmazonPage) {
+    const cookieModule = loadCookieModule();
+    cookieModule.generateAlexaCookie('', '', {
+        proxyOwnIp: '192.168.0.35',
+        proxyPort: 3456,
+        baseAmazonPage,
+        amazonPage: baseAmazonPage,
+        logger: () => {}
+    }, () => {});
+    return capturedProxyOptions;
+}
+
+const deOptions = runProxyOnlyConfig('amazon.de');
+assert.strictEqual(deOptions.baseAmazonPageHandle, '_de');
+
+const comOptions = runProxyOnlyConfig('amazon.com');
+assert.strictEqual(comOptions.baseAmazonPageHandle, '');

--- a/test/proxy-cookie-rewrite.test.js
+++ b/test/proxy-cookie-rewrite.test.js
@@ -4,7 +4,7 @@ const os = require('os');
 const path = require('path');
 const vm = require('vm');
 
-const testName = 'proxy-success-requires-auth-code';
+const testName = 'proxy-cookie-rewrite';
 const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
 const outputFile = path.join(outputDir, `${testName}.txt`);
 const lines = [];
@@ -79,30 +79,8 @@ function loadProxyModule() {
     return module.exports;
 }
 
-function createProxyResponse(location) {
-    return {
-        statusCode: 302,
-        headers: {
-            location
-        },
-        socket: {
-            _host: 'www.amazon.de',
-            parser: {
-                outgoing: {
-                    method: 'POST',
-                    path: '/ap/signin',
-                    getHeader() {
-                        return undefined;
-                    }
-                }
-            }
-        }
-    };
-}
-
 const proxyModule = loadProxyModule();
-const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-success-test-${Date.now()}.json`);
-let callbackData;
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-cookie-test-${Date.now()}.json`);
 
 try {
     const input = {
@@ -116,44 +94,44 @@ try {
         proxyLogLevel: 'silent',
         formerDataStorePath
     };
-    proxyModule.initAmazonProxy(input, (_err, data) => {
-        callbackData = data;
-    });
+    proxyModule.initAmazonProxy(input);
+    const cookieDomainRewrite = capturedProxyOptions.cookieDomainRewrite || {};
+    const cookiePathRewrite = capturedProxyOptions.cookiePathRewrite || {};
+    const cookieDomainRewriteKeys = Object.keys(cookieDomainRewrite);
+    const cookiePathRewriteKeys = Object.keys(cookiePathRewrite);
 
-    const responseLocation = 'https://www.amazon.de/ap/maplanding?openid.mode=id_res&openid.return_to=https%3A%2F%2Fwww.amazon.de%2Fap%2Fmaplanding';
-    const proxyRes = createProxyResponse(responseLocation);
-    const req = {
-        method: 'POST',
-        url: '/www.amazon.de/ap/signin',
-        originalUrl: '/www.amazon.de/ap/signin'
-    };
-
-    capturedProxyOptions.onProxyRes(proxyRes, req, {});
-
-    line('TEST: proxy success requires auth code');
+    line('TEST: proxy cookie rewrite');
     line('');
     line('CODE UNDER TEST:');
-    line('- lib/proxy.js: onProxyRes()');
-    line('- lib/proxy.js: maplanding success detection');
+    line('- lib/proxy.js: cookieDomainRewrite');
+    line('- lib/proxy.js: cookiePathRewrite');
     line('');
     line('INPUT:');
-    line(`response location: ${responseLocation}`);
-    line(`request method: ${req.method}`);
-    line(`request originalUrl: ${req.originalUrl}`);
+    line(`proxyOwnIp: ${input.proxyOwnIp}`);
+    line(`baseAmazonPage: ${input.baseAmazonPage}`);
     line('');
     line('OBSERVED:');
-    line(`callback data present: ${callbackData !== undefined}`);
-    line(`final response location: ${proxyRes.headers.location}`);
+    line(`cookieDomainRewrite keys: ${cookieDomainRewriteKeys.join(', ')}`);
+    line(`cookieDomainRewrite["*"]: ${cookieDomainRewrite['*']}`);
+    line(`cookiePathRewrite keys: ${cookiePathRewriteKeys.join(', ')}`);
+    line(`cookiePathRewrite["*"]: ${cookiePathRewrite['*']}`);
+    line(`cookieDomainRewrite contains proxy IP: ${Object.values(cookieDomainRewrite).includes(input.proxyOwnIp)}`);
     line('');
     line('ASSERTIONS:');
-    recordAssertion('callbackData === undefined', () => {
-        assert.strictEqual(callbackData === undefined, true);
+    recordAssertion('cookieDomainRewrite only has "*" key', () => {
+        assert.deepStrictEqual(cookieDomainRewriteKeys, ['*']);
     });
-    recordAssertion('final location !== local /cookie-success', () => {
-        assert.notStrictEqual(proxyRes.headers.location, 'http://127.0.0.1:3456/cookie-success');
+    recordAssertion('cookieDomainRewrite["*"] === ""', () => {
+        assert.strictEqual(cookieDomainRewrite['*'], '');
     });
-    recordAssertion('final location preserves proxied maplanding path', () => {
-        assert.strictEqual(proxyRes.headers.location, 'http://127.0.0.1:3456/www.amazon.de/ap/maplanding?openid.mode=id_res&openid.return_to=https%3A%2F%2Fwww.amazon.de%2Fap%2Fmaplanding');
+    recordAssertion('cookieDomainRewrite does not contain proxy IP', () => {
+        assert.ok(!Object.values(cookieDomainRewrite).includes(input.proxyOwnIp), 'set-cookie domain must not be rewritten to an IP address');
+    });
+    recordAssertion('cookiePathRewrite only has "*" key', () => {
+        assert.deepStrictEqual(cookiePathRewriteKeys, ['*']);
+    });
+    recordAssertion('cookiePathRewrite["*"] === "/"', () => {
+        assert.strictEqual(cookiePathRewrite['*'], '/');
     });
     line('');
     line('RESULT: PASS');

--- a/test/proxy-cookie-sanitizing.test.js
+++ b/test/proxy-cookie-sanitizing.test.js
@@ -1,0 +1,186 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const testName = 'proxy-cookie-sanitizing';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+let capturedProxyOptions;
+
+function createExpressStub() {
+    return {
+        use() {},
+        get() {},
+        listen() {
+            const server = {
+                address: () => ({ port: 3456 }),
+                on: () => server
+            };
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    capturedProxyOptions = undefined;
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        return function proxyMiddleware() {};
+                    }
+                };
+            }
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+function createProxyRequest(cookie) {
+    const headers = {
+        cookie,
+        host: 'www.amazon.de',
+        origin: 'https://www.amazon.de'
+    };
+    return {
+        getHeader(name) {
+            return headers[name.toLowerCase()];
+        },
+        setHeader(name, value) {
+            headers[name.toLowerCase()] = value;
+        },
+        getHeaders() {
+            return headers;
+        }
+    };
+}
+
+function createProxyResponse(location) {
+    return {
+        statusCode: 302,
+        headers: {
+            location
+        },
+        socket: {
+            _host: 'www.amazon.de',
+            parser: {
+                outgoing: {
+                    method: 'GET',
+                    path: '/ap/maplanding?openid.oa2.authorization_code=AUTH_CODE_FROM_PROXY',
+                    getHeader() {
+                        return undefined;
+                    }
+                }
+            }
+        }
+    };
+}
+
+const proxyModule = loadProxyModule();
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-cookie-sanitizing-test-${Date.now()}.json`);
+let callbackData;
+
+try {
+    const input = {
+        proxyOwnIp: '127.0.0.1',
+        proxyPort: 3456,
+        proxyListenBind: '0.0.0.0',
+        baseAmazonPage: 'amazon.de',
+        baseAmazonPageHandle: '_de',
+        amazonPageProxyLanguage: 'de_DE',
+        acceptLanguage: 'de-DE',
+        proxyLogLevel: 'silent',
+        formerDataStorePath
+    };
+    proxyModule.initAmazonProxy(input, (_err, data) => {
+        callbackData = data;
+    });
+
+    const proxyReq = createProxyRequest('connect.sid=LOCAL_BROWSER; session-id=SID_BROWSER; ubid-acbde=UBID_BROWSER');
+    const req = {
+        method: 'GET',
+        url: '/www.amazon.de/ap/maplanding?openid.oa2.authorization_code=AUTH_CODE_FROM_PROXY',
+        originalUrl: '/www.amazon.de/ap/maplanding?openid.oa2.authorization_code=AUTH_CODE_FROM_PROXY',
+        headers: {
+            host: '127.0.0.1:3456'
+        },
+        on() {}
+    };
+    capturedProxyOptions.onProxyReq(proxyReq, req);
+    capturedProxyOptions.onProxyRes(createProxyResponse('https://www.amazon.de/ap/maplanding?openid.oa2.authorization_code=AUTH_CODE_FROM_PROXY'), req, {});
+
+    line('TEST: proxy callback sanitizes login cookie');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- lib/proxy.js: onProxyReq() proxy cookie capture');
+    line('- lib/proxy.js: callbackCookie loginCookie value');
+    line('');
+    line('OBSERVED:');
+    line(`loginCookie: ${callbackData && callbackData.loginCookie}`);
+    line('');
+    line('ASSERTIONS:');
+    recordAssertion('callback data is present', () => {
+        assert.ok(callbackData);
+    });
+    recordAssertion('loginCookie keeps Amazon session-id', () => {
+        assert.ok(callbackData.loginCookie.includes('session-id=SID_BROWSER'));
+    });
+    recordAssertion('loginCookie keeps Amazon ubid cookie', () => {
+        assert.ok(callbackData.loginCookie.includes('ubid-acbde=UBID_BROWSER'));
+    });
+    recordAssertion('loginCookie removes unrelated local browser cookie', () => {
+        assert.ok(!callbackData.loginCookie.includes('connect.sid=LOCAL_BROWSER'));
+    });
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+} finally {
+    fs.rmSync(formerDataStorePath, { force: true });
+}

--- a/test/proxy-host-switch.test.js
+++ b/test/proxy-host-switch.test.js
@@ -4,7 +4,7 @@ const os = require('os');
 const path = require('path');
 const vm = require('vm');
 
-const testName = 'proxy-initial-url';
+const testName = 'proxy-host-switch';
 const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
 const outputFile = path.join(outputDir, `${testName}.txt`);
 const lines = [];
@@ -49,6 +49,7 @@ function createExpressStub() {
 }
 
 function loadProxyModule() {
+    capturedProxyOptions = undefined;
     const module = { exports: {} };
     const sandbox = {
         Buffer,
@@ -89,85 +90,66 @@ function applyPathRewrite(pathname, req) {
 }
 
 const proxyModule = loadProxyModule();
-const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-test-${Date.now()}.json`);
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-host-test-${Date.now()}.json`);
 
 try {
     const input = {
         proxyOwnIp: '127.0.0.1',
         proxyPort: 3456,
         proxyListenBind: '0.0.0.0',
-        baseAmazonPage: 'amazon.co.uk',
-        baseAmazonPageHandle: '_uk',
-        amazonPageProxyLanguage: 'en_GB',
-        acceptLanguage: 'en-GB',
+        baseAmazonPage: 'amazon.de',
+        baseAmazonPageHandle: '_de',
+        amazonPageProxyLanguage: 'de_DE',
+        acceptLanguage: 'de-DE',
         proxyLogLevel: 'silent',
         formerDataStorePath
     };
     proxyModule.initAmazonProxy(input);
 
-    const req = {
+    const directReq = {
         method: 'GET',
-        url: '/',
+        url: '/www.amazon.com/ap/signin',
+        headers: { host: '127.0.0.1:3456' }
+    };
+    const refererReq = {
+        method: 'POST',
+        url: '/ap/cvf/verify',
         headers: {
-            host: '127.0.0.1:3456'
+            host: '127.0.0.1:3456',
+            referer: 'http://127.0.0.1:3456/www.amazon.com/ap/signin'
         }
     };
 
-    const target = capturedProxyOptions.router(req);
-    const rewrittenPath = applyPathRewrite(req.url, req);
-    const targetUrl = new URL(target);
-    const rewrittenUrl = new URL(rewrittenPath, target);
+    const directTarget = capturedProxyOptions.router(directReq);
+    const directRewrittenPath = applyPathRewrite(directReq.url, directReq);
+    const refererTarget = capturedProxyOptions.router(refererReq);
 
-    line('TEST: proxy initial URL');
+    line('TEST: proxy host switch');
     line('');
     line('CODE UNDER TEST:');
     line('- lib/proxy.js: router()');
-    line('- lib/proxy.js: pathRewrite / rewriteProxyPath()');
-    line('- lib/proxy.js: buildInitialUrl()');
+    line('- lib/proxy.js: rewriteProxyPath()');
     line('');
     line('INPUT:');
     line(`baseAmazonPage: ${input.baseAmazonPage}`);
-    line(`baseAmazonPageHandle: ${input.baseAmazonPageHandle}`);
-    line(`proxy host header: ${req.headers.host}`);
-    line(`request url: ${req.url}`);
+    line(`direct request url: ${directReq.url}`);
+    line(`referer request url: ${refererReq.url}`);
+    line(`referer header: ${refererReq.headers.referer}`);
     line('');
     line('OBSERVED:');
-    line(`router target host: ${targetUrl.host}`);
-    line(`router target search: ${targetUrl.search}`);
-    line(`rewritten pathname: ${rewrittenUrl.pathname}`);
-    line(`rewritten openid.assoc_handle: ${rewrittenUrl.searchParams.get('openid.assoc_handle')}`);
-    line(`rewritten pageId: ${rewrittenUrl.searchParams.get('pageId')}`);
-    line(`rewritten openid.return_to: ${rewrittenUrl.searchParams.get('openid.return_to')}`);
-    line(`rewritten openid.ns.oa2: ${rewrittenUrl.searchParams.get('openid.ns.oa2')}`);
-    line(`rewritten path starts with /ap/signin?: ${rewrittenPath.startsWith('/ap/signin?')}`);
-    line(`rewritten path contains openid.return_to: ${rewrittenPath.includes('openid.return_to=')}`);
-    line(`rewritten path contains regional handle: ${rewrittenPath.includes('amzn_dp_project_dee_ios_uk')}`);
-    line(`rewritten path contains code challenge: ${rewrittenPath.includes('openid.oa2.code_challenge=')}`);
+    line(`direct router target: ${directTarget}`);
+    line(`direct rewritten path: ${directRewrittenPath}`);
+    line(`referer router target: ${refererTarget}`);
     line('');
     line('ASSERTIONS:');
-    recordAssertion('router target host === "www.amazon.co.uk"', () => {
-        assert.strictEqual(targetUrl.host, 'www.amazon.co.uk');
+    recordAssertion('direct router target === "https://www.amazon.com"', () => {
+        assert.strictEqual(directTarget, 'https://www.amazon.com');
     });
-    recordAssertion('router target search === ""', () => {
-        assert.ok(targetUrl.search === '', 'router target search must be empty');
+    recordAssertion('direct rewritten path === "/ap/signin"', () => {
+        assert.strictEqual(directRewrittenPath, '/ap/signin');
     });
-    recordAssertion('rewritten path starts with "/ap/signin?"', () => {
-        assert.ok(rewrittenPath.startsWith('/ap/signin?'), `expected signin path, got ${rewrittenPath}`);
-    });
-    recordAssertion('rewritten assoc handle === "amzn_dp_project_dee_ios_uk"', () => {
-        assert.strictEqual(rewrittenUrl.searchParams.get('openid.assoc_handle'), 'amzn_dp_project_dee_ios_uk');
-    });
-    recordAssertion('rewritten pageId === "amzn_dp_project_dee_ios_uk"', () => {
-        assert.strictEqual(rewrittenUrl.searchParams.get('pageId'), 'amzn_dp_project_dee_ios_uk');
-    });
-    recordAssertion('rewritten path contains "openid.return_to="', () => {
-        assert.ok(rewrittenPath.includes('openid.return_to='));
-    });
-    recordAssertion('rewritten path contains regional "_uk" handle', () => {
-        assert.ok(rewrittenPath.includes('amzn_dp_project_dee_ios_uk'));
-    });
-    recordAssertion('rewritten path contains "openid.oa2.code_challenge="', () => {
-        assert.ok(rewrittenPath.includes('openid.oa2.code_challenge='));
+    recordAssertion('referer router target === "https://www.amazon.com"', () => {
+        assert.strictEqual(refererTarget, 'https://www.amazon.com');
     });
     line('');
     line('RESULT: PASS');

--- a/test/proxy-initial-url.test.js
+++ b/test/proxy-initial-url.test.js
@@ -92,6 +92,9 @@ const targetUrl = new URL(target);
 
 assert.strictEqual(targetUrl.host, 'www.amazon.de');
 assert.strictEqual(targetUrl.search, '', 'router target must not duplicate query parameters supplied by pathRewrite');
+assert.strictEqual(capturedProxyOptions.cookieDomainRewrite['*'], '');
+assert.ok(!Object.values(capturedProxyOptions.cookieDomainRewrite).includes('192.168.0.35'), 'set-cookie domain must not be rewritten to an IP address');
+assert.strictEqual(capturedProxyOptions.cookiePathRewrite['*'], '/');
 assert.ok(rewrittenPath.startsWith('/ap/signin?'), `expected signin path, got ${rewrittenPath}`);
 assert.ok(rewrittenPath.includes('openid.return_to='));
 assert.ok(rewrittenPath.includes('openid.oa2.code_challenge='));

--- a/test/proxy-initial-url.test.js
+++ b/test/proxy-initial-url.test.js
@@ -1,0 +1,97 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+let capturedProxyOptions;
+
+function createExpressStub() {
+    return {
+        use() {},
+        get() {},
+        listen() {
+            const server = {
+                address: () => ({ port: 3456 }),
+                on: () => server
+            };
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        return function proxyMiddleware() {};
+                    }
+                };
+            }
+            if (name === 'cookie') {
+                return { parse: () => ({}) };
+            }
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+function applyPathRewrite(pathname, req) {
+    const rewrite = capturedProxyOptions.pathRewrite;
+    if (typeof rewrite === 'function') return rewrite(pathname, req);
+    for (const pattern of Object.keys(rewrite)) {
+        const regex = new RegExp(pattern);
+        if (regex.test(pathname)) return pathname.replace(regex, rewrite[pattern]);
+    }
+    return pathname;
+}
+
+const proxyModule = loadProxyModule();
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-test-${Date.now()}.json`);
+
+proxyModule.initAmazonProxy({
+    proxyOwnIp: '192.168.0.35',
+    proxyPort: 3456,
+    proxyListenBind: '0.0.0.0',
+    baseAmazonPage: 'amazon.de',
+    baseAmazonPageHandle: '',
+    amazonPageProxyLanguage: 'de_DE',
+    acceptLanguage: 'de-DE',
+    proxyLogLevel: 'silent',
+    formerDataStorePath
+});
+
+const req = {
+    method: 'GET',
+    url: '/',
+    headers: {
+        host: '192.168.0.35:3456'
+    }
+};
+
+const target = capturedProxyOptions.router(req);
+const rewrittenPath = applyPathRewrite(req.url, req);
+
+assert.strictEqual(new URL(target).host, 'www.amazon.de');
+assert.ok(rewrittenPath.startsWith('/ap/signin?'), `expected signin path, got ${rewrittenPath}`);
+assert.ok(rewrittenPath.includes('openid.return_to='));
+assert.ok(rewrittenPath.includes('openid.oa2.code_challenge='));
+
+fs.rmSync(formerDataStorePath, { force: true });

--- a/test/proxy-initial-url.test.js
+++ b/test/proxy-initial-url.test.js
@@ -88,8 +88,10 @@ const req = {
 
 const target = capturedProxyOptions.router(req);
 const rewrittenPath = applyPathRewrite(req.url, req);
+const targetUrl = new URL(target);
 
-assert.strictEqual(new URL(target).host, 'www.amazon.de');
+assert.strictEqual(targetUrl.host, 'www.amazon.de');
+assert.strictEqual(targetUrl.search, '', 'router target must not duplicate query parameters supplied by pathRewrite');
 assert.ok(rewrittenPath.startsWith('/ap/signin?'), `expected signin path, got ${rewrittenPath}`);
 assert.ok(rewrittenPath.includes('openid.return_to='));
 assert.ok(rewrittenPath.includes('openid.oa2.code_challenge='));

--- a/test/proxy-success-requires-auth-code.test.js
+++ b/test/proxy-success-requires-auth-code.test.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+let capturedProxyOptions;
+
+function createExpressStub() {
+    return {
+        use() {},
+        get() {},
+        listen() {
+            const server = {
+                address: () => ({ port: 3456 }),
+                on: () => server
+            };
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    capturedProxyOptions = undefined;
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        return function proxyMiddleware() {};
+                    }
+                };
+            }
+            if (name === 'cookie') {
+                return { parse: () => ({}) };
+            }
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+function createProxyResponse(location) {
+    return {
+        statusCode: 302,
+        headers: {
+            location
+        },
+        socket: {
+            _host: 'www.amazon.de',
+            parser: {
+                outgoing: {
+                    method: 'POST',
+                    path: '/ap/signin',
+                    getHeader() {
+                        return undefined;
+                    }
+                }
+            }
+        }
+    };
+}
+
+const proxyModule = loadProxyModule();
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-success-test-${Date.now()}.json`);
+let callbackData;
+
+proxyModule.initAmazonProxy({
+    proxyOwnIp: '192.168.0.35',
+    proxyPort: 3456,
+    proxyListenBind: '0.0.0.0',
+    baseAmazonPage: 'amazon.de',
+    baseAmazonPageHandle: '_de',
+    amazonPageProxyLanguage: 'de_DE',
+    acceptLanguage: 'de-DE',
+    proxyLogLevel: 'silent',
+    formerDataStorePath
+}, (_err, data) => {
+    callbackData = data;
+});
+
+const proxyRes = createProxyResponse('https://www.amazon.de/ap/maplanding?openid.mode=id_res&openid.return_to=https%3A%2F%2Fwww.amazon.de%2Fap%2Fmaplanding');
+capturedProxyOptions.onProxyRes(proxyRes, {
+    method: 'POST',
+    url: '/www.amazon.de/ap/signin',
+    originalUrl: '/www.amazon.de/ap/signin'
+}, {});
+
+assert.strictEqual(callbackData, undefined);
+assert.notStrictEqual(proxyRes.headers.location, 'http://192.168.0.35:3456/cookie-success');
+assert.strictEqual(proxyRes.headers.location, 'http://192.168.0.35:3456/www.amazon.de/ap/maplanding?openid.mode=id_res&openid.return_to=https%3A%2F%2Fwww.amazon.de%2Fap%2Fmaplanding');
+
+fs.rmSync(formerDataStorePath, { force: true });

--- a/test/refresh-skips-app-registration.test.js
+++ b/test/refresh-skips-app-registration.test.js
@@ -1,0 +1,266 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EventEmitter = require('events');
+
+const testName = 'refresh-skips-app-registration';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+function parseCookies(cookieHeader) {
+    const result = {};
+    for (const part of String(cookieHeader || '').split(';')) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const idx = trimmed.indexOf('=');
+        if (idx === -1) continue;
+        result[trimmed.slice(0, idx)] = trimmed.slice(idx + 1);
+    }
+    return result;
+}
+
+const cookieFile = path.join(__dirname, '..', 'alexa-cookie.js');
+const source = fs.readFileSync(cookieFile, 'utf8');
+
+function loadCookieModule(overrides = {}) {
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(cookieFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'https' && overrides.https) return overrides.https;
+            if (name === './lib/proxy.js') {
+                return {
+                    initAmazonProxy() {
+                        throw new Error('proxy should not start in this test');
+                    }
+                };
+            }
+            if (name === 'cookie') return { parse: parseCookies };
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: cookieFile });
+    return module.exports;
+}
+
+function createFakeHttps(calls) {
+    function responseFor(options) {
+        if (options.path === '/auth/token') {
+            return {
+                statusCode: 200,
+                headers: { 'set-cookie': ['session-id=SID_REFRESH; Path=/; Domain=.amazon.de'] },
+                body: JSON.stringify({ access_token: 'ACCESS_TOKEN_AFTER_REFRESH' })
+            };
+        }
+        if (options.host === 'api.amazonalexa.com' && options.path === '/v1/devices/@self/capabilities') {
+            return { statusCode: 204, headers: {}, body: '' };
+        }
+        if (options.path === '/ap/exchangetoken/cookies') {
+            return {
+                statusCode: 200,
+                headers: { 'set-cookie': ['exchange-cookie=EXCHANGE_HEADER; Path=/; Domain=.amazon.de'] },
+                body: JSON.stringify({
+                    response: {
+                        tokens: {
+                            cookies: {
+                                '.amazon.de': [
+                                    { Name: 'session-id', Value: 'SID_LOCAL' },
+                                    { Name: 'ubid-acbde', Value: 'UBID_LOCAL' }
+                                ]
+                            }
+                        }
+                    }
+                })
+            };
+        }
+        if (options.path === '/api/language') {
+            return {
+                statusCode: 200,
+                headers: { 'set-cookie': ['csrf=CSRF_FROM_API; Path=/; Domain=.amazon.de'] },
+                body: '{}'
+            };
+        }
+        throw new Error(`Unexpected request: ${options.method || 'GET'} ${options.host}${options.path}`);
+    }
+
+    return {
+        request(options, callback) {
+            const req = new EventEmitter();
+            let requestBody = '';
+            req.write = (chunk) => {
+                requestBody += chunk;
+            };
+            req.end = () => {
+                calls.push({
+                    method: options.method || 'GET',
+                    host: options.host,
+                    path: options.path,
+                    status: null,
+                    hasAuthorization: Boolean(options.headers && options.headers.authorization),
+                    bodyLength: requestBody.length
+                });
+                const response = responseFor(options);
+                calls[calls.length - 1].status = response.statusCode;
+                const res = new EventEmitter();
+                res.statusCode = response.statusCode;
+                res.headers = response.headers || {};
+                res.socket = { end() {} };
+                callback(res);
+                if (response.body) res.emit('data', Buffer.from(response.body));
+                res.emit('end');
+            };
+            return req;
+        }
+    };
+}
+
+function refresh(cookieModule, options) {
+    return new Promise((resolve, reject) => {
+        cookieModule.refreshAlexaCookie(options, (err, data) => {
+            if (err) reject(err);
+            else resolve(data);
+        });
+    });
+}
+
+(async () => {
+    const calls = [];
+    const cookieModule = loadCookieModule({ https: createFakeHttps(calls) });
+    const formerRegistrationData = {
+        loginCookie: 'frc=FRC_OLD; map-md=MAPMD_OLD; session-id=SID_OLD',
+        localCookie: 'old-local=OLD',
+        refreshToken: 'REFRESH_TOKEN_OLD',
+        accessToken: 'ACCESS_TOKEN_OLD',
+        macDms: 'MAC_DMS_OLD',
+        csrf: 'CSRF_OLD',
+        amazonPage: 'amazon.de',
+        authorization_code: 'AUTH_CODE_FROM_LOGIN',
+        verifier: 'VERIFIER_FROM_LOGIN',
+        dataVersion: 2
+    };
+
+    try {
+        const result = await refresh(cookieModule, {
+            baseAmazonPage: 'amazon.de',
+            amazonPage: 'amazon.de',
+            acceptLanguage: 'de-DE',
+            formerRegistrationData,
+            logger: () => {}
+        });
+
+        const paths = calls.map((call) => call.path);
+        const capabilityCall = calls.find((call) => call.path === '/v1/devices/@self/capabilities');
+
+        line('TEST: refresh skips app registration');
+        line('');
+        line('CODE UNDER TEST:');
+        line('- alexa-cookie.js: refreshAlexaCookie()');
+        line('- alexa-cookie.js: registerTokenCapabilities()');
+        line('- alexa-cookie.js: getLocalCookies()');
+        line('');
+        line('INPUT:');
+        line('baseAmazonPage: amazon.de');
+        line('amazonPage: amazon.de');
+        line(`formerRegistrationData has refreshToken: ${Boolean(formerRegistrationData.refreshToken)}`);
+        line(`formerRegistrationData has accessToken: ${Boolean(formerRegistrationData.accessToken)}`);
+        line(`formerRegistrationData has authorization_code: ${Object.prototype.hasOwnProperty.call(formerRegistrationData, 'authorization_code')}`);
+        line(`formerRegistrationData has verifier: ${Object.prototype.hasOwnProperty.call(formerRegistrationData, 'verifier')}`);
+        line('');
+        line('OBSERVED REQUESTS:');
+        calls.forEach((call) => {
+            line(`- ${call.method} ${call.host}${call.path} -> ${call.status}`);
+        });
+        line('');
+        line('OBSERVED RESULT:');
+        line(`result amazonPage: ${result.amazonPage}`);
+        line(`result has accessToken: ${Boolean(result.accessToken)}`);
+        line(`result has refreshToken: ${Boolean(result.refreshToken)}`);
+        line(`result has macDms: ${Boolean(result.macDms)}`);
+        line(`result has csrf: ${Boolean(result.csrf)}`);
+        line(`result has authorization_code: ${Object.prototype.hasOwnProperty.call(result, 'authorization_code')}`);
+        line(`result has verifier: ${Object.prototype.hasOwnProperty.call(result, 'verifier')}`);
+        line(`result localCookie includes refreshed session-id: ${result.localCookie.includes('session-id=SID_LOCAL')}`);
+        line('');
+        line('ASSERTIONS:');
+        recordAssertion('requests include /auth/token', () => {
+            assert.ok(paths.includes('/auth/token'));
+        });
+        recordAssertion('requests include /v1/devices/@self/capabilities', () => {
+            assert.ok(paths.includes('/v1/devices/@self/capabilities'));
+        });
+        recordAssertion('requests include /ap/exchangetoken/cookies', () => {
+            assert.ok(paths.includes('/ap/exchangetoken/cookies'));
+        });
+        recordAssertion('requests include /api/language', () => {
+            assert.ok(paths.includes('/api/language'));
+        });
+        recordAssertion('requests do not include /auth/register', () => {
+            assert.ok(!paths.includes('/auth/register'));
+        });
+        recordAssertion('capability request uses PUT api.amazonalexa.com', () => {
+            assert.strictEqual(capabilityCall.host, 'api.amazonalexa.com');
+            assert.strictEqual(capabilityCall.method, 'PUT');
+        });
+        recordAssertion('capability request has authorization header', () => {
+            assert.strictEqual(capabilityCall.hasAuthorization, true);
+        });
+        recordAssertion('result accessToken was refreshed', () => {
+            assert.strictEqual(result.accessToken, 'ACCESS_TOKEN_AFTER_REFRESH');
+        });
+        recordAssertion('result refreshToken preserved', () => {
+            assert.strictEqual(result.refreshToken, 'REFRESH_TOKEN_OLD');
+        });
+        recordAssertion('result macDms preserved', () => {
+            assert.strictEqual(result.macDms, 'MAC_DMS_OLD');
+        });
+        recordAssertion('result csrf refreshed from API cookie', () => {
+            assert.strictEqual(result.csrf, 'CSRF_FROM_API');
+        });
+        recordAssertion('result localCookie contains exchanged session-id', () => {
+            assert.ok(result.localCookie.includes('session-id=SID_LOCAL'));
+        });
+        recordAssertion('result does not keep authorization_code', () => {
+            assert.strictEqual(Object.prototype.hasOwnProperty.call(result, 'authorization_code'), false);
+        });
+        recordAssertion('result does not keep verifier', () => {
+            assert.strictEqual(Object.prototype.hasOwnProperty.call(result, 'verifier'), false);
+        });
+        line('');
+        line('RESULT: PASS');
+        writeOutput();
+    } catch (err) {
+        if (!lines.includes('RESULT: PASS')) {
+            line('');
+            line('RESULT: FAIL');
+            writeOutput();
+        }
+        throw err;
+    }
+})();

--- a/test/refresh-skips-app-registration.test.js
+++ b/test/refresh-skips-app-registration.test.js
@@ -206,6 +206,7 @@ function refresh(cookieModule, options) {
         line(`result has csrf: ${Boolean(result.csrf)}`);
         line(`result has authorization_code: ${Object.prototype.hasOwnProperty.call(result, 'authorization_code')}`);
         line(`result has verifier: ${Object.prototype.hasOwnProperty.call(result, 'verifier')}`);
+        line(`result loginCookie includes exchange-cookie: ${result.loginCookie.includes('exchange-cookie=EXCHANGE_HEADER')}`);
         line(`result localCookie includes refreshed session-id: ${result.localCookie.includes('session-id=SID_LOCAL')}`);
         line('');
         line('ASSERTIONS:');
@@ -245,6 +246,9 @@ function refresh(cookieModule, options) {
         });
         recordAssertion('result localCookie contains exchanged session-id', () => {
             assert.ok(result.localCookie.includes('session-id=SID_LOCAL'));
+        });
+        recordAssertion('result loginCookie excludes non-Amazon exchange response cookie', () => {
+            assert.ok(!result.loginCookie.includes('exchange-cookie=EXCHANGE_HEADER'));
         });
         recordAssertion('result does not keep authorization_code', () => {
             assert.strictEqual(Object.prototype.hasOwnProperty.call(result, 'authorization_code'), false);

--- a/test/registration-hardening.test.js
+++ b/test/registration-hardening.test.js
@@ -1,0 +1,261 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const EventEmitter = require('events');
+
+const testName = 'registration-hardening';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+function parseCookies(cookieHeader) {
+    const result = {};
+    for (const part of String(cookieHeader || '').split(';')) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const idx = trimmed.indexOf('=');
+        if (idx === -1) continue;
+        result[trimmed.slice(0, idx)] = trimmed.slice(idx + 1);
+    }
+    return result;
+}
+
+const cookieFile = path.join(__dirname, '..', 'alexa-cookie.js');
+const source = fs.readFileSync(cookieFile, 'utf8');
+
+function createProxyStub(proxyData) {
+    return {
+        initAmazonProxy(_options, callbackCookie) {
+            callbackCookie(null, Object.assign({
+                loginCookie: 'connect.sid=LOCAL_BROWSER; session-id=SID_BROWSER; ubid-acbde=UBID_BROWSER; frc=FRC_PROXY; map-md=MAPMD_PROXY',
+                authorization_code: 'AUTH_CODE_FROM_PROXY',
+                verifier: 'VERIFIER_FROM_PROXY',
+                deviceId: 'DEVICE_ID_FROM_PROXY',
+                frc: 'FRC_PROXY',
+                'map-md': 'MAPMD_PROXY'
+            }, proxyData || {}));
+        }
+    };
+}
+
+function loadCookieModule(overrides = {}) {
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(cookieFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'https') return overrides.https;
+            if (name === './lib/proxy.js') return createProxyStub(overrides.proxyData);
+            if (name === 'cookie') return { parse: parseCookies };
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: cookieFile });
+    return module.exports;
+}
+
+function createFakeHttps(config, calls) {
+    function responseFor(options) {
+        if (options.path === '/auth/register') {
+            return {
+                statusCode: 200,
+                headers: { 'set-cookie': ['session-id=SID_REGISTER; Path=/; Domain=.amazon.de'] },
+                body: JSON.stringify({
+                    response: {
+                        success: {
+                            tokens: {
+                                bearer: {
+                                    refresh_token: 'REFRESH_TOKEN_AFTER_REGISTER',
+                                    access_token: 'ACCESS_TOKEN_AFTER_REGISTER'
+                                },
+                                mac_dms: {
+                                    device_private_key: 'PRIVATE_KEY_AFTER_REGISTER',
+                                    adp_token: 'ADP_TOKEN_AFTER_REGISTER'
+                                },
+                                website_cookies: [
+                                    { Name: 'session-token', Value: 'SESSION_TOKEN_AFTER_REGISTER' },
+                                    { Name: 'at-acbde', Value: 'AT_AFTER_REGISTER' },
+                                    { Name: 'sess-at-acbde', Value: 'SESS_AT_AFTER_REGISTER' }
+                                ]
+                            }
+                        }
+                    }
+                })
+            };
+        }
+        if (options.host === 'api.amazonalexa.com' && options.path === '/v1/devices/@self/capabilities') {
+            return { statusCode: 204, headers: {}, body: '' };
+        }
+        if (options.path === '/api/users/me?platform=ios&version=2.2.651540.0') {
+            if (config.userDataMode === 'empty401') {
+                return { statusCode: 401, headers: {}, body: '' };
+            }
+            return {
+                statusCode: 200,
+                headers: {},
+                body: JSON.stringify({ marketPlaceDomainName: 'www.amazon.de' })
+            };
+        }
+        if (options.path === '/ap/exchangetoken/cookies') {
+            if (config.localCookieMode === 'error') {
+                return { statusCode: 200, headers: {}, body: '{}' };
+            }
+            return {
+                statusCode: 200,
+                headers: { 'set-cookie': ['session-id=SID_LOCAL_HEADER; Path=/; Domain=.amazon.de'] },
+                body: JSON.stringify({
+                    response: {
+                        tokens: {
+                            cookies: {
+                                '.amazon.de': [
+                                    { Name: 'session-id', Value: 'SID_LOCAL' },
+                                    { Name: 'ubid-acbde', Value: 'UBID_LOCAL' }
+                                ]
+                            }
+                        }
+                    }
+                })
+            };
+        }
+        if (options.path === '/api/language') {
+            return {
+                statusCode: 200,
+                headers: { 'set-cookie': ['csrf=CSRF_FROM_API; Path=/; Domain=.amazon.de'] },
+                body: '{}'
+            };
+        }
+        throw new Error(`Unexpected request: ${options.method || 'GET'} ${options.host}${options.path}`);
+    }
+
+    return {
+        request(options, callback) {
+            const req = new EventEmitter();
+            let requestBody = '';
+            req.write = (chunk) => {
+                requestBody += chunk;
+            };
+            req.end = () => {
+                const call = {
+                    method: options.method || 'GET',
+                    host: options.host,
+                    path: options.path,
+                    headers: Object.assign({}, options.headers),
+                    requestBody,
+                    status: null
+                };
+                calls.push(call);
+                const response = responseFor(options);
+                call.status = response.statusCode;
+                const res = new EventEmitter();
+                res.statusCode = response.statusCode;
+                res.headers = response.headers || {};
+                res.socket = { end() {} };
+                callback(res);
+                if (response.body) res.emit('data', Buffer.from(response.body));
+                res.emit('end');
+            };
+            return req;
+        }
+    };
+}
+
+function runScenario(config = {}) {
+    const calls = [];
+    const callbacks = [];
+    const cookieModule = loadCookieModule({
+        https: createFakeHttps(config, calls),
+        proxyData: config.proxyData
+    });
+
+    cookieModule.generateAlexaCookie({
+        proxyOwnIp: '127.0.0.1',
+        proxyPort: 3456,
+        proxyListenBind: '0.0.0.0',
+        baseAmazonPage: 'amazon.de',
+        amazonPage: 'amazon.de',
+        acceptLanguage: 'de-DE',
+        proxyLogLevel: 'silent',
+        logger: () => {}
+    }, (err, data) => {
+        callbacks.push({ err, data });
+    });
+
+    return { calls, callbacks };
+}
+
+try {
+    line('TEST: registration hardening');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- alexa-cookie.js: handleTokenRegistration()');
+    line('- alexa-cookie.js: optional /api/users/me handling');
+    line('- alexa-cookie.js: getLocalCookies() error path after registration');
+    line('');
+
+    const sanitizedScenario = runScenario();
+    const registerCall = sanitizedScenario.calls.find((call) => call.path === '/auth/register');
+    const registerBody = JSON.parse(registerCall.requestBody);
+
+    line('ASSERTIONS:');
+    recordAssertion('registration Cookie header removes unrelated local browser cookie', () => {
+        assert.ok(!registerCall.headers.Cookie.includes('connect.sid=LOCAL_BROWSER'));
+    });
+    recordAssertion('registration body removes unrelated local browser cookie', () => {
+        assert.ok(!registerBody.cookies.website_cookies.some((cookie) => cookie.Name === 'connect.sid'));
+    });
+    recordAssertion('registration body keeps Amazon session cookie', () => {
+        assert.ok(registerBody.cookies.website_cookies.some((cookie) => cookie.Name === 'session-id' && cookie.Value === 'SID_BROWSER'));
+    });
+
+    const emptyUserDataScenario = runScenario({ userDataMode: 'empty401' });
+    recordAssertion('empty optional user-data response continues when amazonPage is known', () => {
+        assert.strictEqual(emptyUserDataScenario.callbacks.length, 1);
+        assert.ifError(emptyUserDataScenario.callbacks[0].err);
+        assert.strictEqual(emptyUserDataScenario.callbacks[0].data.amazonPage, 'amazon.de');
+        assert.ok(emptyUserDataScenario.callbacks[0].data.localCookie.includes('session-id=SID_LOCAL'));
+    });
+
+    const localCookieErrorScenario = runScenario({ localCookieMode: 'error' });
+    recordAssertion('local-cookie retrieval error stops registration callback flow', () => {
+        assert.strictEqual(localCookieErrorScenario.callbacks.length, 1);
+        assert.ok(localCookieErrorScenario.callbacks[0].err);
+        assert.match(localCookieErrorScenario.callbacks[0].err.message, /No cookies in Exchange response/);
+        assert.strictEqual(localCookieErrorScenario.calls.filter((call) => call.path === '/api/language').length, 0);
+    });
+
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+}


### PR DESCRIPTION
changes:
- keep refresh on the existing registration instead of starting a new one
- update the proxy user agent/app version metadata
- remove the fixed `authority` header
- handle redirects between `amazon.de`, `www.amazon.com`, `amazon.com`, and `alexa.amazon.com`
- rewrite proxy URLs back and forth consistently for those hosts

fixes the broken login flow described in #190, where the proxied Amazon page can reject valid credentials or later redirect to invalid local URLs like `/www.amazon.com/404`.

tested:
- `node --check alexa-cookie.js`
- `node --check lib/proxy.js`
- successful cookie retrieval in Node-RED installation