### PR TITLE
Cookie refresh

### DIFF
--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -39,6 +39,19 @@ function AlexaCookie() {
 
     let Cookie = '';
 
+    const isAmazonCookieName = name => /^(session-id|session-id-time|session-token|ubid-.+|lc-.+|x-.+|at-.+|sess-at-.+|frc|map-md|csrf|sid|csm-hit|i18n-prefs|sp-cdn|skin)$/.test(name);
+
+    const sanitizeAmazonCookie = cookie => {
+        const cookies = cookieTools.parse(cookie || '');
+        let sanitizedCookie = '';
+        for (const name of Object.keys(cookies)) {
+            if (isAmazonCookieName(name)) {
+                sanitizedCookie += `${name}=${cookies[name]}; `;
+            }
+        }
+        return sanitizedCookie.replace(/[; ]*$/, '');
+    };
+
     const addCookies = (Cookie, headers) => {
         if (!headers || !headers['set-cookie']) return Cookie;
         const cookies = cookieTools.parse(Cookie || '');
@@ -408,6 +421,7 @@ function AlexaCookie() {
         _options.logger && _options.logger(`Handle token registration Start: ${JSON.stringify(loginData)}`);
 
         loginData.deviceAppName = _options.deviceAppName;
+        loginData.loginCookie = sanitizeAmazonCookie(loginData.loginCookie);
 
         let deviceSerial;
         if (!_options.formerRegistrationData || !_options.formerRegistrationData.deviceSerial) {
@@ -553,22 +567,34 @@ function AlexaCookie() {
                 _options.logger && _options.logger(JSON.stringify(options));
                 request(options, (error, response, body) => {
                     if (!error) {
+                        if (!response || response.statusCode < 200 || response.statusCode >= 300 || !body) {
+                            _options.logger && _options.logger(`Get User data Response: status=${response && response.statusCode}, body=${JSON.stringify(body)}`);
+                            if (!_options.amazonPage) {
+                                callback && callback(new Error(`Could not get user data from Amazon: HTTP ${response && response.statusCode}`), null);
+                                return;
+                            }
+                            loginData.amazonPage = _options.amazonPage;
+                        } else {
                         try {
                             if (typeof body !== 'object') body = JSON.parse(body);
                         } catch (err) {
                             _options.logger && _options.logger(`Get User data Response: ${JSON.stringify(body)}`);
-                            callback && callback(err, null);
-                            return;
+                            if (!_options.amazonPage) {
+                                callback && callback(err, null);
+                                return;
+                            }
+                            loginData.amazonPage = _options.amazonPage;
                         }
                         _options.logger && _options.logger(`Get User data Response: ${JSON.stringify(body)}`);
 
                         Cookie = addCookies(Cookie, response.headers);
 
-                        if (body.marketPlaceDomainName) {
+                        if (body && body.marketPlaceDomainName) {
                             const pos = body.marketPlaceDomainName.indexOf('.');
                             if (pos !== -1) _options.amazonPage = body.marketPlaceDomainName.substr(pos + 1);
                         }
                         loginData.amazonPage = _options.amazonPage;
+                        }
                     } else if (error && (!_options || !_options.amazonPage)) {
                         callback && callback(error, null);
                         return;
@@ -583,6 +609,7 @@ function AlexaCookie() {
                     getLocalCookies(loginData.amazonPage, loginData.refreshToken, (err, localCookie) => {
                         if (err) {
                             callback && callback(err, null);
+                            return;
                         }
 
                         loginData.localCookie = localCookie;
@@ -798,6 +825,7 @@ function AlexaCookie() {
             getLocalCookies(_options.baseAmazonPage, _options.formerRegistrationData.refreshToken, (err, comCookie) => {
                 if (err) {
                     callback && callback(err, null);
+                    return;
                 }
 
                 // Restore frc and map-md
@@ -806,8 +834,31 @@ function AlexaCookie() {
                 newCookie += `map-md=${initCookies['map-md']}; `;
                 newCookie += comCookie;
 
-                _options.formerRegistrationData.loginCookie = newCookie;
-                handleTokenRegistration(_options, _options.formerRegistrationData, callback);
+                _options.formerRegistrationData.loginCookie = sanitizeAmazonCookie(newCookie);
+                const amazonPage = _options.formerRegistrationData.amazonPage || _options.amazonPage || _options.baseAmazonPage;
+                getLocalCookies(amazonPage, _options.formerRegistrationData.refreshToken, (err, localCookie) => {
+                    if (err) {
+                        callback && callback(err, null);
+                        return;
+                    }
+
+                    _options.formerRegistrationData.localCookie = localCookie;
+                    getCSRFFromCookies(_options.formerRegistrationData.localCookie, _options, (err, resData) => {
+                        if (err) {
+                            callback && callback(new Error(`Error getting csrf for ${amazonPage}`), null);
+                            return;
+                        }
+                        _options.formerRegistrationData.amazonPage = amazonPage;
+                        _options.formerRegistrationData.localCookie = resData.cookie;
+                        _options.formerRegistrationData.csrf = resData.csrf;
+                        _options.formerRegistrationData.tokenDate = Date.now();
+                        _options.formerRegistrationData.dataVersion = 2;
+                        delete _options.formerRegistrationData.accessToken;
+
+                        _options.logger && _options.logger(`Final Refresh Result: ${JSON.stringify(_options.formerRegistrationData)}`);
+                        callback && callback(null, _options.formerRegistrationData);
+                    });
+                });
             });
         });
     };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -34,6 +34,21 @@ function addCookies(Cookie, headers) {
     return Cookie;
 }
 
+function isAmazonCookieName(name) {
+    return /^(session-id|session-id-time|session-token|ubid-.+|lc-.+|x-.+|at-.+|sess-at-.+|frc|map-md|csrf|sid|csm-hit|i18n-prefs|sp-cdn|skin)$/.test(name);
+}
+
+function sanitizeAmazonCookie(cookie) {
+    const cookies = cookieTools.parse(cookie || '');
+    let sanitizedCookie = '';
+    for (const name of Object.keys(cookies)) {
+        if (isAmazonCookieName(name)) {
+            sanitizedCookie += `${name}=${cookies[name]}; `;
+        }
+    }
+    return sanitizedCookie.replace(/[; ]*$/, '');
+}
+
 function customStringify(v, func, intent) {
     const cache = new Map();
     return JSON.stringify(v, function (key, value) {
@@ -328,7 +343,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             _options.logger && _options.logger(`Alexa-Cookie: Proxy catched parameters: ${JSON.stringify(queryParams)}`);
 
             callbackCookie && callbackCookie(null, {
-                'loginCookie': proxyCookies,
+                'loginCookie': sanitizeAmazonCookie(proxyCookies),
                 'authorization_code': queryParams['openid.oa2.authorization_code'],
                 'frc': initialCookies.frc,
                 'map-md': initialCookies['map-md'],


### PR DESCRIPTION
Fixes cookie refresh/login handling after recent Amazon auth changes.

This addresses cases where:
- refresh succeeds up to token/cookie exchange
- optional `/api/users/me` returns 401 with an empty body
- parsing the empty response crashes with `Unexpected end of JSON input`
- proxy login may include unrelated local browser cookies when opened through a host that already has cookies

Changes:
- sanitize proxy-captured cookies to keep only Amazon-relevant cookie names
- tolerate empty/non-2xx user-data responses when an Amazon domain is already known
- avoid continuing after local-cookie retrieval errors
- keep refreshed registration data instead of failing hard on the optional user-data lookup

Issues:
https://github.com/Apollon77/ioBroker.alexa2/issues/1376
https://github.com/Apollon77/ioBroker.alexa2/issues/1380

