### PR TITLE
fix: use assigned random port in proxy URL rewriting (#197)

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -72,7 +72,7 @@ function customStringify(v, func, intent) {
 
 function initAmazonProxy(_options, callbackCookie, callbackListening) {
     const initialCookies = {};
-    const proxyBase = `http://${_options.proxyOwnIp}:${_options.proxyPort}/`;
+    const proxyBase = () => `http://${_options.proxyOwnIp}:${_options.proxyPort}/`;
     const defaultAmazonHost = `www.${_options.baseAmazonPage}`;
     const amazonProxyHosts = [];
 
@@ -106,7 +106,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
     function amazonHostFromProxyUrl(url) {
         if (!url) return null;
         for (const host of amazonProxyHosts) {
-            if (url === `${proxyBase}${host}` || url.startsWith(`${proxyBase}${host}/`)) {
+            if (url === `${proxyBase()}${host}` || url.startsWith(`${proxyBase()}${host}/`)) {
                 return host;
             }
         }
@@ -286,22 +286,23 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         data = data.replace(/&#x2F;/g, '/');
         for (const host of amazonProxyHosts) {
             const hostRegex = new RegExp(`https?://${escapeRegex(host)}:?[0-9]*/`, 'g');
-            data = data.replace(hostRegex, `${proxyBase}${host}/`);
+            data = data.replace(hostRegex, `${proxyBase()}${host}/`);
         }
         //_options.logger && _options.logger('REPLACEHOSTS: ' + dataOrig + ' --> ' + data);
         return data;
     }
 
     function replaceHostsBack(data) {
+        const base = proxyBase();
         for (const host of amazonProxyHosts) {
-            const hostRegex = new RegExp(`${escapeRegex(proxyBase)}${escapeRegex(host)}/`, 'g');
+            const hostRegex = new RegExp(`${escapeRegex(base)}${escapeRegex(host)}/`, 'g');
             data = data.replace(hostRegex, `https://${host}/`);
         }
-        if (data === proxyBase) {
+        if (data === base) {
             data = returnedInitUrl;
         }
-        else if (data.startsWith(proxyBase)) {
-            data = `https://${defaultAmazonHost}/${data.slice(proxyBase.length)}`;
+        else if (data.startsWith(base)) {
+            data = `https://${defaultAmazonHost}/${data.slice(base.length)}`;
         }
         return data;
     }
@@ -466,7 +467,8 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         _options.proxyPort = undefined;
     }
     const server = app.listen(_options.proxyPort, _options.proxyListenBind, function() {
-        _options.logger && _options.logger(`Alexa-Cookie: Proxy-Server listening on port ${server.address().port}`);
+        _options.proxyPort = this.address().port;
+        _options.logger && _options.logger(`Alexa-Cookie: Proxy-Server listening on port ${_options.proxyPort}`);
         callbackListening && callbackListening(server);
         callbackListening = null;
     }).on('error', err => {

--- a/test/proxy-random-port.test.js
+++ b/test/proxy-random-port.test.js
@@ -1,0 +1,147 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const testName = 'proxy-random-port';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+const ASSIGNED_PORT = 3456;
+let capturedProxyOptions;
+
+function createExpressStub() {
+    return {
+        use() {},
+        get() {},
+        listen(port, bind, callback) {
+            const server = {
+                address: () => ({ port: ASSIGNED_PORT }),
+                on: () => server
+            };
+            callback && callback.call(server);
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    capturedProxyOptions = undefined;
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        return function proxyMiddleware() {};
+                    }
+                };
+            }
+            if (name === 'cookie') {
+                return { parse: () => ({}) };
+            }
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+const proxyModule = loadProxyModule();
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-random-port-test-${Date.now()}.json`);
+
+try {
+    const input = {
+        proxyOwnIp: '127.0.0.1',
+        proxyPort: 0,
+        proxyListenBind: '0.0.0.0',
+        baseAmazonPage: 'amazon.de',
+        baseAmazonPageHandle: '_de',
+        amazonPageProxyLanguage: 'de_DE',
+        acceptLanguage: 'de-DE',
+        proxyLogLevel: 'silent',
+        formerDataStorePath
+    };
+    proxyModule.initAmazonProxy(input);
+
+    const refererReq = {
+        method: 'POST',
+        url: '/ap/cvf/verify',
+        headers: {
+            host: `127.0.0.1:${ASSIGNED_PORT}`,
+            referer: `http://127.0.0.1:${ASSIGNED_PORT}/www.amazon.com/ap/signin`
+        }
+    };
+
+    const refererTarget = capturedProxyOptions.router(refererReq);
+
+    line('TEST: proxy random port (proxyPort 0)');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- lib/proxy.js: proxyBase() lazy resolution');
+    line('- lib/proxy.js: listen callback writes assigned port to _options.proxyPort');
+    line('- lib/proxy.js: router()/amazonHostFromProxyUrl()');
+    line('');
+    line('INPUT:');
+    line(`proxyPort: ${input.proxyPort}`);
+    line(`assigned listen port: ${ASSIGNED_PORT}`);
+    line(`referer header: ${refererReq.headers.referer}`);
+    line('');
+    line('OBSERVED:');
+    line(`_options.proxyPort after init: ${input.proxyPort}`);
+    line(`referer router target: ${refererTarget}`);
+    line('');
+    line('ASSERTIONS:');
+    recordAssertion(`_options.proxyPort updated to ${ASSIGNED_PORT}`, () => {
+        assert.strictEqual(input.proxyPort, ASSIGNED_PORT);
+    });
+    recordAssertion('referer router target === "https://www.amazon.com"', () => {
+        assert.strictEqual(refererTarget, 'https://www.amazon.com');
+    });
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+} finally {
+    fs.rmSync(formerDataStorePath, { force: true });
+}


### PR DESCRIPTION
## Problem

Fixes #197 — proxy forwarding uses port `0` in rewritten URLs when the proxy port is left empty (random port mode).

`initAmazonProxy` captured `proxyBase` as a const at function start:

```js
const proxyBase = `http://${_options.proxyOwnIp}:${_options.proxyPort}/`;
```

At that point `_options.proxyPort` is still `0` (the default when empty). The real port is only known after `app.listen(0)` picks one — but `proxyBase` already froze `http://ip:0/`. All body/URL rewriting (`replaceHosts`, `replaceHostsBack`, `amazonHostFromProxyUrl`) then emitted unreachable `:0` links, breaking proxy login on random ports.

This regressed in `cb09b25` ("Fix proxy redirects for Amazon MFA host switches"), which hoisted the previously-inline (request-time) base URL into a captured const.

## Fix

- Make `proxyBase` a lazy function so it reads the live `_options.proxyPort` at call time (after the port is assigned).
- Write the assigned port back to `_options.proxyPort` in the listen callback, using `this.address().port` (the server is the `listening` emitter) so the lib is self-contained and avoids a TDZ on `server`.

## Test

Adds `test/proxy-random-port.test.js`: runs `initAmazonProxy` with `proxyPort: 0` and a listen stub reporting an assigned port, then asserts the port writeback and that referer routing resolves via `proxyBase()` at the real port. Verified to fail on the pre-fix code and pass after.

Full suite: 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)