### PR TITLE
chore: run existing tests in CI

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -15,6 +15,7 @@ on:
       # pre-releases
       - "v?[0-9]+.[0-9]+.[0-9]+-**"
   pull_request: {}
+  workflow_dispatch: {}
 
 # Cancel previous PR/branch runs when a new commit is pushed
 concurrency:
@@ -47,8 +48,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-#      - name: Run local tests
-#        run: npm test
+      - name: Run local tests
+        run: npm test
 
   # Deploys the final package to NPM
   deploy:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "url": "https://github.com/Apollon77/alexa-cookie/issues"
   },
   "scripts": {
+    "test": "node test/run-tests.js",
     "release": "release-script"
   },
   "engines": {

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,0 +1,46 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const testDir = __dirname;
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(os.tmpdir(), 'alexa-cookie-test-output');
+const tests = fs.readdirSync(testDir)
+    .filter(name => name.endsWith('.test.js'))
+    .sort();
+
+if (!tests.length) {
+    console.error('No test files found.');
+    process.exit(1);
+}
+
+console.log(`Writing test proof output to ${outputDir}`);
+
+for (const test of tests) {
+    const testPath = path.join(testDir, test);
+    console.log(`\n> ${test}`);
+
+    const result = spawnSync(process.execPath, [testPath], {
+        stdio: 'inherit',
+        env: {
+            ...process.env,
+            ALEXA_COOKIE_TEST_OUTPUT_DIR: outputDir
+        }
+    });
+
+    if (result.error) {
+        console.error(`Failed to run ${test}: ${result.error.message}`);
+        process.exit(1);
+    }
+
+    if (result.signal) {
+        console.error(`${test} terminated by signal ${result.signal}`);
+        process.exit(1);
+    }
+
+    if (result.status !== 0) {
+        process.exit(result.status || 1);
+    }
+}
+
+console.log(`\n${tests.length} test files passed.`);


### PR DESCRIPTION
### Summary
- add an npm test script that runs the existing test/*.test.js files
- enable the existing GitHub Actions workflow to run npm test

This is the first preparatory step for upcoming test coverage PRs (see #199). After this is merged, the actual test PRs will follow separately.

### Verification
- git diff --check
- node --check test/run-tests.js
- npm test — 9 test files passed