### PR TITLE
test: expand proxy coverage

### DIFF
--- a/test/proxy-host-switch.test.js
+++ b/test/proxy-host-switch.test.js
@@ -79,6 +79,25 @@ function loadProxyModule() {
     return module.exports;
 }
 
+function createProxyRequest(initialHeaders = {}) {
+    const headers = {};
+    for (const name of Object.keys(initialHeaders)) {
+        headers[name.toLowerCase()] = initialHeaders[name];
+    }
+
+    return {
+        getHeader(name) {
+            return headers[name.toLowerCase()];
+        },
+        setHeader(name, value) {
+            headers[name.toLowerCase()] = value;
+        },
+        getHeaders() {
+            return { ...headers };
+        }
+    };
+}
+
 function applyPathRewrite(pathname, req) {
     const rewrite = capturedProxyOptions.pathRewrite;
     if (typeof rewrite === 'function') return rewrite(pathname, req);
@@ -114,6 +133,7 @@ try {
     const refererReq = {
         method: 'POST',
         url: '/ap/cvf/verify',
+        on() {},
         headers: {
             host: '127.0.0.1:3456',
             referer: 'http://127.0.0.1:3456/www.amazon.com/ap/signin'
@@ -123,6 +143,13 @@ try {
     const directTarget = capturedProxyOptions.router(directReq);
     const directRewrittenPath = applyPathRewrite(directReq.url, directReq);
     const refererTarget = capturedProxyOptions.router(refererReq);
+    const refererRewrittenPath = applyPathRewrite(refererReq.url, refererReq);
+    const refererProxyReq = createProxyRequest({
+        host: 'www.amazon.com',
+        referer: 'http://127.0.0.1:3456/www.amazon.com/ap/signin'
+    });
+    capturedProxyOptions.onProxyReq(refererProxyReq, refererReq, {});
+    const refererProxyHeaders = refererProxyReq.getHeaders();
 
     line('TEST: proxy host switch');
     line('');
@@ -140,6 +167,9 @@ try {
     line(`direct router target: ${directTarget}`);
     line(`direct rewritten path: ${directRewrittenPath}`);
     line(`referer router target: ${refererTarget}`);
+    line(`referer rewritten path: ${refererRewrittenPath}`);
+    line(`referer proxy request referer: ${refererProxyHeaders.referer}`);
+    line(`referer proxy request origin: ${refererProxyHeaders.origin}`);
     line('');
     line('ASSERTIONS:');
     recordAssertion('direct router target === "https://www.amazon.com"', () => {
@@ -150,6 +180,15 @@ try {
     });
     recordAssertion('referer router target === "https://www.amazon.com"', () => {
         assert.strictEqual(refererTarget, 'https://www.amazon.com');
+    });
+    recordAssertion('referer rewritten path === "/ap/cvf/verify"', () => {
+        assert.strictEqual(refererRewrittenPath, '/ap/cvf/verify');
+    });
+    recordAssertion('referer proxy request restores Amazon referer', () => {
+        assert.strictEqual(refererProxyHeaders.referer, 'https://www.amazon.com/ap/signin');
+    });
+    recordAssertion('referer proxy request sets matching Amazon origin', () => {
+        assert.strictEqual(refererProxyHeaders.origin, 'https://www.amazon.com');
     });
     line('');
     line('RESULT: PASS');

--- a/test/proxy-initial-url.test.js
+++ b/test/proxy-initial-url.test.js
@@ -117,6 +117,10 @@ try {
     const rewrittenPath = applyPathRewrite(req.url, req);
     const targetUrl = new URL(target);
     const rewrittenUrl = new URL(rewrittenPath, target);
+    const expectedReturnTo = 'https://www.amazon.co.uk/ap/maplanding';
+    const expectedOAuthNamespace = 'http://www.amazon.co.uk/ap/ext/oauth/2';
+    const clientId = rewrittenUrl.searchParams.get('openid.oa2.client_id');
+    const codeChallenge = rewrittenUrl.searchParams.get('openid.oa2.code_challenge');
 
     line('TEST: proxy initial URL');
     line('');
@@ -139,9 +143,13 @@ try {
     line(`rewritten pageId: ${rewrittenUrl.searchParams.get('pageId')}`);
     line(`rewritten openid.return_to: ${rewrittenUrl.searchParams.get('openid.return_to')}`);
     line(`rewritten openid.ns.oa2: ${rewrittenUrl.searchParams.get('openid.ns.oa2')}`);
+    line(`rewritten openid.oa2.client_id: ${clientId}`);
+    line(`rewritten openid.oa2.response_type: ${rewrittenUrl.searchParams.get('openid.oa2.response_type')}`);
+    line(`rewritten openid.oa2.scope: ${rewrittenUrl.searchParams.get('openid.oa2.scope')}`);
+    line(`rewritten openid.oa2.code_challenge_method: ${rewrittenUrl.searchParams.get('openid.oa2.code_challenge_method')}`);
+    line(`rewritten language: ${rewrittenUrl.searchParams.get('language')}`);
     line(`rewritten path starts with /ap/signin?: ${rewrittenPath.startsWith('/ap/signin?')}`);
     line(`rewritten path contains openid.return_to: ${rewrittenPath.includes('openid.return_to=')}`);
-    line(`rewritten path contains regional handle: ${rewrittenPath.includes('amzn_dp_project_dee_ios_uk')}`);
     line(`rewritten path contains code challenge: ${rewrittenPath.includes('openid.oa2.code_challenge=')}`);
     line('');
     line('ASSERTIONS:');
@@ -160,14 +168,23 @@ try {
     recordAssertion('rewritten pageId === "amzn_dp_project_dee_ios_uk"', () => {
         assert.strictEqual(rewrittenUrl.searchParams.get('pageId'), 'amzn_dp_project_dee_ios_uk');
     });
-    recordAssertion('rewritten path contains "openid.return_to="', () => {
-        assert.ok(rewrittenPath.includes('openid.return_to='));
+    recordAssertion('rewritten return_to targets regional maplanding', () => {
+        assert.strictEqual(rewrittenUrl.searchParams.get('openid.return_to'), expectedReturnTo);
     });
-    recordAssertion('rewritten path contains regional "_uk" handle', () => {
-        assert.ok(rewrittenPath.includes('amzn_dp_project_dee_ios_uk'));
+    recordAssertion('rewritten OAuth namespace targets regional Amazon page', () => {
+        assert.strictEqual(rewrittenUrl.searchParams.get('openid.ns.oa2'), expectedOAuthNamespace);
     });
-    recordAssertion('rewritten path contains "openid.oa2.code_challenge="', () => {
-        assert.ok(rewrittenPath.includes('openid.oa2.code_challenge='));
+    recordAssertion('rewritten OAuth request asks for device auth code', () => {
+        assert.ok(clientId && clientId.startsWith('device:'), 'client id must identify generated device');
+        assert.strictEqual(rewrittenUrl.searchParams.get('openid.oa2.response_type'), 'code');
+        assert.strictEqual(rewrittenUrl.searchParams.get('openid.oa2.scope'), 'device_auth_access');
+    });
+    recordAssertion('rewritten code challenge uses S256 and is present', () => {
+        assert.strictEqual(rewrittenUrl.searchParams.get('openid.oa2.code_challenge_method'), 'S256');
+        assert.ok(codeChallenge && codeChallenge.length > 20, 'code challenge must not be empty');
+    });
+    recordAssertion('rewritten language matches proxy language', () => {
+        assert.strictEqual(rewrittenUrl.searchParams.get('language'), input.amazonPageProxyLanguage);
     });
     line('');
     line('RESULT: PASS');

--- a/test/proxy-success-callback.test.js
+++ b/test/proxy-success-callback.test.js
@@ -1,0 +1,253 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const testName = 'proxy-success-callback';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+function parseCookies(cookieHeader) {
+    const result = {};
+    for (const part of String(cookieHeader || '').split(';')) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const idx = trimmed.indexOf('=');
+        if (idx === -1) continue;
+        result[trimmed.slice(0, idx)] = trimmed.slice(idx + 1);
+    }
+    return result;
+}
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+let capturedProxyOptions;
+
+function createExpressStub() {
+    return {
+        use() {},
+        get() {},
+        listen() {
+            const server = {
+                address: () => ({ port: 3456 }),
+                on: () => server
+            };
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    capturedProxyOptions = undefined;
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        return function proxyMiddleware() {};
+                    }
+                };
+            }
+            if (name === 'cookie') return { parse: parseCookies };
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+function createProxyResponse(location) {
+    return {
+        statusCode: 200,
+        headers: {
+            location,
+            'set-cookie': ['session-id=SID_PROXY; Path=/; Domain=.amazon.de; Secure']
+        },
+        socket: {
+            _host: 'www.amazon.de',
+            parser: {
+                outgoing: {
+                    method: 'POST',
+                    path: '/ap/signin',
+                    getHeader() {
+                        return undefined;
+                    }
+                }
+            }
+        }
+    };
+}
+
+function createProxyRequest(initialHeaders = {}) {
+    const headers = {};
+    for (const name of Object.keys(initialHeaders)) {
+        headers[name.toLowerCase()] = initialHeaders[name];
+    }
+
+    return {
+        getHeader(name) {
+            return headers[name.toLowerCase()];
+        },
+        setHeader(name, value) {
+            headers[name.toLowerCase()] = value;
+        },
+        getHeaders() {
+            return { ...headers };
+        }
+    };
+}
+
+const proxyModule = loadProxyModule();
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-callback-test-${Date.now()}.json`);
+let callbackErr;
+let callbackData;
+
+try {
+    const input = {
+        proxyOwnIp: '127.0.0.1',
+        proxyPort: 3456,
+        proxyListenBind: '0.0.0.0',
+        baseAmazonPage: 'amazon.de',
+        baseAmazonPageHandle: '_de',
+        amazonPageProxyLanguage: 'de_DE',
+        acceptLanguage: 'de-DE',
+        proxyLogLevel: 'silent',
+        formerDataStorePath,
+        formerRegistrationData: {
+            frc: 'FRC_FROM_FORMER_DATA',
+            'map-md': 'MAPMD_FROM_FORMER_DATA'
+        }
+    };
+    proxyModule.initAmazonProxy(input, (err, data) => {
+        callbackErr = err;
+        callbackData = data;
+    });
+
+    const responseLocation = 'https://www.amazon.de/ap/maplanding?openid.mode=id_res&openid.oa2.authorization_code=AUTH%20CODE%2FVALUE';
+    const proxyRes = createProxyResponse(responseLocation);
+    const req = {
+        method: 'POST',
+        url: '/www.amazon.de/ap/signin',
+        originalUrl: '/www.amazon.de/ap/signin',
+        on() {}
+    };
+    const proxyReq = createProxyRequest({
+        host: 'www.amazon.de'
+    });
+
+    capturedProxyOptions.onProxyReq(proxyReq, req, {});
+    capturedProxyOptions.onProxyRes(proxyRes, req, {});
+    const proxyRequestCookies = parseCookies(proxyReq.getHeader('cookie'));
+    const callbackCookies = parseCookies(callbackData && callbackData.loginCookie);
+
+    line('TEST: proxy success callback');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- lib/proxy.js: onProxyReq()');
+    line('- lib/proxy.js: onProxyRes()');
+    line('- lib/proxy.js: maplanding success callback');
+    line('');
+    line('INPUT:');
+    line(`response location: ${responseLocation}`);
+    line(`request method: ${req.method}`);
+    line(`request originalUrl: ${req.originalUrl}`);
+    line('');
+    line('OBSERVED:');
+    line(`callback error present: ${Boolean(callbackErr)}`);
+    line(`callback data present: ${callbackData !== undefined}`);
+    line(`final response location: ${proxyRes.headers.location}`);
+    line(`final status: ${proxyRes.statusCode}`);
+    line(`proxy request cookie: ${proxyReq.getHeader('cookie')}`);
+    line(`callback loginCookie names: ${Object.keys(callbackCookies).join(', ')}`);
+    line('');
+    line('ASSERTIONS:');
+    recordAssertion('callback has no error', () => {
+        assert.strictEqual(callbackErr, null);
+    });
+    recordAssertion('callback data is present', () => {
+        assert.ok(callbackData);
+    });
+    recordAssertion('successful maplanding redirects to local cookie success page', () => {
+        assert.strictEqual(proxyRes.headers.location, 'http://127.0.0.1:3456/cookie-success');
+    });
+    recordAssertion('successful maplanding keeps redirect status', () => {
+        assert.strictEqual(proxyRes.statusCode, 302);
+    });
+    recordAssertion('callback contains decoded authorization code', () => {
+        assert.strictEqual(callbackData.authorization_code, 'AUTH CODE/VALUE');
+    });
+    recordAssertion('callback contains collected proxy cookie', () => {
+        assert.strictEqual(callbackCookies['session-id'], 'SID_PROXY');
+    });
+    recordAssertion('proxy request includes frc from former data', () => {
+        assert.strictEqual(proxyRequestCookies.frc, 'FRC_FROM_FORMER_DATA');
+    });
+    recordAssertion('proxy request includes map-md from former data', () => {
+        assert.strictEqual(proxyRequestCookies['map-md'], 'MAPMD_FROM_FORMER_DATA');
+    });
+    recordAssertion('callback loginCookie includes frc for later token exchange', () => {
+        assert.strictEqual(callbackCookies.frc, 'FRC_FROM_FORMER_DATA');
+    });
+    recordAssertion('callback loginCookie includes map-md for later token exchange', () => {
+        assert.strictEqual(callbackCookies['map-md'], 'MAPMD_FROM_FORMER_DATA');
+    });
+    recordAssertion('callback reuses frc from former data', () => {
+        assert.strictEqual(callbackData.frc, input.formerRegistrationData.frc);
+    });
+    recordAssertion('callback reuses map-md from former data', () => {
+        assert.strictEqual(callbackData['map-md'], input.formerRegistrationData['map-md']);
+    });
+    recordAssertion('callback contains deviceId for later token exchange', () => {
+        assert.strictEqual(typeof callbackData.deviceId, 'string');
+        assert.ok(callbackData.deviceId.length > 20);
+    });
+    recordAssertion('callback contains verifier for later token exchange', () => {
+        assert.strictEqual(typeof callbackData.verifier, 'string');
+        assert.ok(callbackData.verifier.length > 20);
+    });
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+} finally {
+    fs.rmSync(formerDataStorePath, { force: true });
+}


### PR DESCRIPTION
- verify that proxy host switches update `Origin` and restore the expected Amazon `Referer`
- strengthen initial sign-in URL coverage for regional and OAuth parameters
- cover the successful proxy callback, including the authorization code, collected cookies, and reused registration data

This PR only adds and extends tests. It does not change runtime behavior.

ref #199 