### PR TITLE
Fix CSRF fallback reuse across refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Thank you for that work.
 
 ### __WORK IN PROGRESS__
 * (GiacomoCa) Do not replace amazon URLs inside parameters to prevent redirect and rewrite issues; Fixes 404 errors during 2FA
+* (sidey79) Allows to fetch Cookies multiple times with one instance
 
 ### 5.0.5 (2026-07-06)
 * (@Apollon77) Fix Proxy URL when no static port is provided

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -216,7 +216,7 @@ function AlexaCookie() {
 
     const getCSRFFromCookies = (cookie, _options, callback) => {
         // get CSRF
-        const csrfUrls = csrfOptions;
+        const csrfUrls = [...csrfOptions];
 
         function csrfTry() {
             const path = csrfUrls.shift();

--- a/test/refresh-skips-app-registration.test.js
+++ b/test/refresh-skips-app-registration.test.js
@@ -100,12 +100,20 @@ function createFakeHttps(calls) {
                 })
             };
         }
-        if (options.path === '/api/language') {
+        if (options.path === '/api/strings') {
             return {
                 statusCode: 200,
                 headers: { 'set-cookie': ['csrf=CSRF_FROM_API; Path=/; Domain=.amazon.de'] },
                 body: '{}'
             };
+        }
+        if ([
+            '/api/language',
+            '/spa/index.html',
+            '/api/devices-v2/device?cached=false',
+            '/templates/oobe/d-device-pick.handlebars'
+        ].includes(options.path)) {
+            return { statusCode: 200, headers: {}, body: '{}' };
         }
         throw new Error(`Unexpected request: ${options.method || 'GET'} ${options.host}${options.path}`);
     }
@@ -168,6 +176,13 @@ function refresh(cookieModule, options) {
 
     try {
         const result = await refresh(cookieModule, {
+            baseAmazonPage: 'amazon.de',
+            amazonPage: 'amazon.de',
+            acceptLanguage: 'de-DE',
+            formerRegistrationData,
+            logger: () => {}
+        });
+        const secondResult = await refresh(cookieModule, {
             baseAmazonPage: 'amazon.de',
             amazonPage: 'amazon.de',
             acceptLanguage: 'de-DE',
@@ -243,6 +258,10 @@ function refresh(cookieModule, options) {
         });
         recordAssertion('result csrf refreshed from API cookie', () => {
             assert.strictEqual(result.csrf, 'CSRF_FROM_API');
+        });
+        recordAssertion('consecutive refresh retries all CSRF endpoints', () => {
+            assert.strictEqual(paths.filter(path => path === '/api/strings').length, 2);
+            assert.strictEqual(secondResult.csrf, 'CSRF_FROM_API');
         });
         recordAssertion('result localCookie contains exchanged session-id', () => {
             assert.ok(result.localCookie.includes('session-id=SID_LOCAL'));


### PR DESCRIPTION
## Summary

Reset the CSRF fallback URL list for every cookie refresh instead of mutating the module-level array.

## Root cause

`getCSRFFromCookies()` assigned the module-level `csrfOptions` array directly to `csrfUrls` and consumed it with `shift()`. After one or more refresh attempts in the same Node.js process, later attempts therefore started with a shortened or empty list. Once exhausted, the request path became `undefined` and the refreshed registration data contained no CSRF token.

## Fix

Create a shallow copy with `[...csrfOptions]` for each invocation.

The regression test performs two consecutive refreshes in the same module instance and only returns the CSRF cookie from the final fallback endpoint. Both refreshes must traverse the complete fallback sequence successfully.

## Impact

Long-running consumers can refresh Alexa cookies repeatedly without requiring a process or container restart to restore the CSRF endpoint list.

This was found while integrating alexa-cookie2 into the [FHEM Alexa Cookie Service](https://github.com/fhem/alexa-cookie-service).

## Validation

- `npm test`: all 9 test files pass
- Regression check without the fix: the second refresh requests `alexa.amazon.deundefined` and fails