### PR TITLE
fix(proxy): un-rewrite proxy-prefixed URLs echoed back to Amazon

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Partly based on [Amazon Alexa Remote Control](http://blog.loetzimmer.de/2017/10/
 Thank you for that work.
 
 ## Changelog:
+
+### __WORK IN PROGRESS__
+* (GiacomoCa) Do not replace amazon URLs inside parameters to prevent redirect and rewrite issues; Fixes 404 errors during 2FA
+
 ### 5.0.5 (2026-07-06)
 * (@Apollon77) Fix Proxy URL when no static port is provided
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -198,17 +198,47 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         return `https://www.${_options.baseAmazonPage}/ap/signin?openid.return_to=https%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fmaplanding&openid.assoc_handle=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&pageId=amzn_dp_project_dee_ios${_options.baseAmazonPageHandle}&accountStatusPolicy=P1&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns.oa2=http%3A%2F%2Fwww.${_options.baseAmazonPage}%2Fap%2Fext%2Foauth%2F2&openid.oa2.client_id=device%3A${deviceId}&openid.ns.pape=http%3A%2F%2Fspecs.openid.net%2Fextensions%2Fpape%2F1.0&openid.oa2.response_type=code&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.pape.max_auth_age=0&openid.oa2.scope=device_auth_access&openid.oa2.code_challenge_method=S256&openid.oa2.code_challenge=${code_challenge}&language=${_options.amazonPageProxyLanguage}`;
     }
 
+    function fixEmbeddedProxyUrls(pathAndQuery) {
+        const qIndex = pathAndQuery.indexOf('?');
+        if (qIndex === -1) return pathAndQuery;
+        const p = pathAndQuery.slice(0, qIndex);
+        const qs = pathAndQuery.slice(qIndex + 1);
+        let params;
+        try {
+            params = new URLSearchParams(qs);
+        } catch (_e) {
+            return pathAndQuery;
+        }
+        let changed = false;
+        for (const key of params.keys()) {
+            const value = params.get(key);
+            const fixed = replaceHostsBack(value);
+            if (fixed !== value) {
+                params.set(key, fixed);
+                changed = true;
+            }
+        }
+        if (changed) {
+            _options.logger && _options.logger(`Alexa-Cookie: Fixed embedded proxy URL(s) in outgoing request query`);
+        }
+        return changed ? `${p}?${params.toString()}` : pathAndQuery;
+    }
+
     function rewriteProxyPath(url, req) {
+        let result;
         const urlHost = amazonHostFromProxyPath(url);
         if (urlHost) {
-            return url.replace(new RegExp(`^/${escapeRegex(urlHost)}`), '') || '/';
+            result = url.replace(new RegExp(`^/${escapeRegex(urlHost)}`), '') || '/';
         }
-        if (req && req.headers && req.headers.host === `${_options.proxyOwnIp}:${_options.proxyPort}` && url === '/') {
+        else if (req && req.headers && req.headers.host === `${_options.proxyOwnIp}:${_options.proxyPort}` && url === '/') {
             const initialUrl = returnedInitUrl || buildInitialUrl();
             const parsed = new URL(initialUrl);
-            return `${parsed.pathname}${parsed.search}`;
+            result = `${parsed.pathname}${parsed.search}`;
         }
-        return url;
+        else {
+            result = url;
+        }
+        return fixEmbeddedProxyUrls(result);
     }
 
     // proxy middleware options
@@ -367,10 +397,27 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
                 modified = true;
             }
 
-            let postBody = '';
-            req.on('data', chunk => {
-                postBody += chunk.toString(); // convert Buffer to string
-            });
+            if (req.body && typeof req.body === 'object') {
+                let bodyChanged = false;
+                for (const key of Object.keys(req.body)) {
+                    const value = req.body[key];
+                    if (typeof value !== 'string') continue;
+                    const fixed = replaceHostsBack(value);
+                    if (fixed !== value) {
+                        req.body[key] = fixed;
+                        bodyChanged = true;
+                    }
+                }
+                if (bodyChanged) {
+                    _options.logger && _options.logger('Alexa-Cookie: Fixed embedded proxy URL(s) in outgoing POST body');
+                }
+                // req.body was already fully buffered and parsed by bufferUrlencodedBody()
+                // before this middleware runs, so the original stream is drained and the
+                // default http-proxy pipe-through is a no-op; write our (possibly fixed) body.
+                const bodyData = querystring.stringify(req.body);
+                proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+                proxyReq.write(bodyData);
+            }
         }
         _options.proxyLogLevel === 'debug' && _options.logger && _options.logger(`Alexa-Cookie: Proxy-Request: (modified:${modified})${customStringify(proxyReq, null, 2)}`);
     }
@@ -452,12 +499,31 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         });
     }
 
+    // Fully buffer+parse `application/x-www-form-urlencoded` POST bodies before the proxy
+    // middleware sees them, so onProxyReq can rewrite fields and re-send the body itself
+    // (the stream is drained by the time http-proxy would otherwise pipe it through).
+    function bufferUrlencodedBody(req, res, next) {
+        const contentType = req.headers['content-type'] || '';
+        if (req.method !== 'POST' || contentType.indexOf('application/x-www-form-urlencoded') === -1) {
+            return next();
+        }
+        let raw = '';
+        req.on('data', chunk => {
+            raw += chunk;
+        });
+        req.on('end', () => {
+            req.body = querystring.parse(raw);
+            next();
+        });
+    }
+
     // create the proxy (without context)
     const myProxy = proxy('!/cookie-success', optionsAlexa);
 
     // mount `exampleProxy` in web server
     const app = express();
 
+    app.use(bufferUrlencodedBody);
     app.use(myProxy);
     app.get('/cookie-success', function(req, res) {
         res.send(_options.proxyCloseWindowHTML);

--- a/test/proxy-embedded-url-rewrite.test.js
+++ b/test/proxy-embedded-url-rewrite.test.js
@@ -1,0 +1,295 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const querystring = require('querystring');
+const vm = require('vm');
+
+const testName = 'proxy-embedded-url-rewrite';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+let capturedProxyOptions;
+let capturedProxyMiddleware;
+let capturedMiddlewares;
+
+function createExpressStub() {
+    return {
+        use(handler) {
+            capturedMiddlewares.push(handler);
+        },
+        get() {},
+        listen() {
+            const server = {
+                address: () => ({ port: 3456 }),
+                on: () => server
+            };
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    capturedProxyOptions = undefined;
+    capturedProxyMiddleware = undefined;
+    capturedMiddlewares = [];
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        // rewriteProxyPath() un-rewrites query parameters with URLSearchParams; without it in
+        // the sandbox the code under test silently falls back to the unmodified path.
+        URLSearchParams,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        capturedProxyMiddleware = function proxyMiddleware() {};
+                        return capturedProxyMiddleware;
+                    }
+                };
+            }
+            if (name === 'cookie') {
+                return { parse: () => ({}) };
+            }
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+function applyPathRewrite(pathname, req) {
+    const rewrite = capturedProxyOptions.pathRewrite;
+    if (typeof rewrite === 'function') return rewrite(pathname, req);
+    for (const pattern of Object.keys(rewrite)) {
+        const regex = new RegExp(pattern);
+        if (regex.test(pathname)) return pathname.replace(regex, rewrite[pattern]);
+    }
+    return pathname;
+}
+
+function createProxyReqStub(headers = {}) {
+    const written = [];
+    const stored = { ...headers };
+    return {
+        written,
+        getHeaders: () => ({ ...stored }),
+        getHeader: name => stored[name.toLowerCase()],
+        setHeader(name, value) {
+            stored[name.toLowerCase()] = value;
+        },
+        write(chunk) {
+            written.push(chunk);
+        }
+    };
+}
+
+// A minimal readable request: `on()` records listeners so the body can be emitted on demand.
+function createReqStub({ method, url, headers }) {
+    const listeners = {};
+    return {
+        method,
+        url,
+        headers,
+        listeners,
+        on(event, handler) {
+            listeners[event] = handler;
+            return this;
+        }
+    };
+}
+
+// Drives the buffering middleware the same way express would: hand it the request, then let
+// the request stream emit its body.
+function runBufferMiddleware(middleware, req, rawBody) {
+    // Nothing mounted ahead of the proxy: report it instead of crashing, so a run against an
+    // unpatched lib/proxy.js still produces the assertion report below.
+    if (typeof middleware !== 'function') return false;
+    let nextCalled = false;
+    middleware(req, {}, () => {
+        nextCalled = true;
+    });
+    if (req.listeners.data && rawBody) req.listeners.data(Buffer.from(rawBody));
+    if (req.listeners.end) req.listeners.end();
+    return nextCalled;
+}
+
+const proxyModule = loadProxyModule();
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-embedded-url-test-${Date.now()}.json`);
+
+try {
+    const input = {
+        proxyOwnIp: '127.0.0.1',
+        proxyPort: 3456,
+        proxyListenBind: '0.0.0.0',
+        baseAmazonPage: 'amazon.de',
+        baseAmazonPageHandle: '_de',
+        amazonPageProxyLanguage: 'de_DE',
+        acceptLanguage: 'de-DE',
+        proxyLogLevel: 'silent',
+        formerDataStorePath
+    };
+    proxyModule.initAmazonProxy(input);
+
+    const bufferMiddleware = capturedMiddlewares.filter(handler => handler !== capturedProxyMiddleware)[0];
+
+    // --- GET: `openid.return_to` pointing back at the proxy (the #137 polling loop) ---
+    const pollReq = {
+        method: 'GET',
+        url: '/www.amazon.com/ap/cvf/approval/poll?openid.return_to=http%3A%2F%2F127.0.0.1%3A3456%2Fwww.amazon.com%2Fap%2Fmaplanding&pageId=amzn_dp_project_dee_ios_de',
+        headers: { host: '127.0.0.1:3456' }
+    };
+    const pollRewritten = applyPathRewrite(pollReq.url, pollReq);
+    const pollParams = new URLSearchParams(pollRewritten.slice(pollRewritten.indexOf('?') + 1));
+
+    // --- GET: a query with nothing to fix must come through byte-identical ---
+    const cleanReq = {
+        method: 'GET',
+        url: '/www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Fap%2Fmaplanding&language=de_DE',
+        headers: { host: '127.0.0.1:3456' }
+    };
+    const cleanRewritten = applyPathRewrite(cleanReq.url, cleanReq);
+
+    // --- POST: `openid.return_to` in an url-encoded body (the verifyOtp 404) ---
+    const otpBody = 'openid.return_to=http%3A%2F%2F127.0.0.1%3A3456%2Fwww.amazon.com%2Fap%2Fmaplanding&code=123456';
+    const otpReq = createReqStub({
+        method: 'POST',
+        url: '/ap/cvf/approval/verifyOtp',
+        headers: {
+            host: '127.0.0.1:3456',
+            'content-type': 'application/x-www-form-urlencoded'
+        }
+    });
+    const otpNextCalled = runBufferMiddleware(bufferMiddleware, otpReq, otpBody);
+    const otpParsedBody = { ...otpReq.body };
+    const otpProxyReq = createProxyReqStub({ host: 'www.amazon.com', 'content-length': String(Buffer.byteLength(otpBody)) });
+    capturedProxyOptions.onProxyReq(otpProxyReq, otpReq);
+    const otpForwarded = otpProxyReq.written.join('');
+    const otpForwardedFields = querystring.parse(otpForwarded);
+
+    // --- POST: a non-urlencoded body must not be buffered, parsed or re-sent ---
+    const jsonReq = createReqStub({
+        method: 'POST',
+        url: '/ap/cvf/approval/poll',
+        headers: {
+            host: '127.0.0.1:3456',
+            'content-type': 'application/json'
+        }
+    });
+    const jsonNextCalled = runBufferMiddleware(bufferMiddleware, jsonReq, '{"foo":"bar"}');
+    const jsonProxyReq = createProxyReqStub({ host: 'www.amazon.com' });
+    capturedProxyOptions.onProxyReq(jsonProxyReq, jsonReq);
+
+    line('TEST: proxy embedded url rewrite (regression for #137)');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- lib/proxy.js: rewriteProxyPath() / fixEmbeddedProxyUrls()');
+    line('- lib/proxy.js: bufferUrlencodedBody()');
+    line('- lib/proxy.js: onProxyReq() POST body handling');
+    line('');
+    line('INPUT:');
+    line(`proxy base: http://${input.proxyOwnIp}:${input.proxyPort}/`);
+    line(`GET poll url: ${pollReq.url}`);
+    line(`GET clean url: ${cleanReq.url}`);
+    line(`POST verifyOtp body: ${otpBody}`);
+    line('POST json content-type: application/json');
+    line('');
+    line('OBSERVED:');
+    line(`middlewares mounted before proxy: ${capturedMiddlewares.length - 1}`);
+    line(`GET poll rewritten: ${pollRewritten}`);
+    line(`GET poll openid.return_to: ${pollParams.get('openid.return_to')}`);
+    line(`GET clean rewritten: ${cleanRewritten}`);
+    line(`POST buffer middleware called next(): ${otpNextCalled}`);
+    line(`POST parsed body: ${JSON.stringify(otpParsedBody)}`);
+    line(`POST forwarded body: ${otpForwarded}`);
+    line(`POST forwarded content-length: ${otpProxyReq.getHeader('content-length')}`);
+    line(`POST json parsed body: ${JSON.stringify(jsonReq.body)}`);
+    line(`POST json forwarded chunks: ${jsonProxyReq.written.length}`);
+    line(`POST json content-length: ${jsonProxyReq.getHeader('content-length')}`);
+    line('');
+    line('ASSERTIONS:');
+    recordAssertion('GET path is stripped of the proxy host prefix', () => {
+        assert.strictEqual(pollRewritten.split('?')[0], '/ap/cvf/approval/poll');
+    });
+    recordAssertion('GET query openid.return_to points back at amazon.com', () => {
+        assert.strictEqual(pollParams.get('openid.return_to'), 'https://www.amazon.com/ap/maplanding');
+    });
+    recordAssertion('GET query keeps the untouched parameters', () => {
+        assert.strictEqual(pollParams.get('pageId'), 'amzn_dp_project_dee_ios_de');
+    });
+    recordAssertion('GET query without proxy urls is returned unchanged', () => {
+        assert.strictEqual(cleanRewritten, '/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Fap%2Fmaplanding&language=de_DE');
+    });
+    recordAssertion('one middleware is mounted ahead of the proxy middleware', () => {
+        assert.strictEqual(capturedMiddlewares.length - 1, 1);
+        assert.strictEqual(typeof bufferMiddleware, 'function');
+    });
+    recordAssertion('urlencoded POST body is buffered and parsed before next()', () => {
+        assert.strictEqual(otpNextCalled, true);
+        assert.strictEqual(otpParsedBody['openid.return_to'], 'http://127.0.0.1:3456/www.amazon.com/ap/maplanding');
+        assert.strictEqual(otpParsedBody.code, '123456');
+    });
+    recordAssertion('POST body openid.return_to points back at amazon.com', () => {
+        assert.strictEqual(otpForwardedFields['openid.return_to'], 'https://www.amazon.com/ap/maplanding');
+    });
+    recordAssertion('POST body keeps the untouched fields', () => {
+        assert.strictEqual(otpForwardedFields.code, '123456');
+    });
+    recordAssertion('POST forwarded body is written exactly once', () => {
+        assert.strictEqual(otpProxyReq.written.length, 1);
+    });
+    recordAssertion('POST content-length matches the forwarded body', () => {
+        assert.strictEqual(Number(otpProxyReq.getHeader('content-length')), Buffer.byteLength(otpForwarded));
+        assert.notStrictEqual(Buffer.byteLength(otpForwarded), Buffer.byteLength(otpBody));
+    });
+    recordAssertion('non-urlencoded POST is passed through untouched', () => {
+        assert.strictEqual(jsonNextCalled, true);
+        assert.strictEqual(jsonReq.body, undefined);
+        assert.strictEqual(jsonProxyReq.written.length, 0);
+        assert.strictEqual(jsonProxyReq.getHeader('content-length'), undefined);
+    });
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+} finally {
+    fs.rmSync(formerDataStorePath, { force: true });
+}


### PR DESCRIPTION
## The bug

The proxy rewrites every `amazon.com` URL it finds in response bodies so the
browser can keep navigating through the proxy. That rewrite also touches URLs
Amazon embeds as *data* rather than as links to follow - most notably
`openid.return_to` in the 2FA / device-approval flow
(`/ap/cvf/approval/poll`, `/ap/cvf/approval/verifyOtp`).

When those get echoed back to Amazon still pointing at the proxy instead of
the real host, Amazon rejects the request with a redirect to `/a/c/404`, and
the client-side polling JS reacts to the 404 by reloading the page - forever.
The login can never complete past the 2FA/approval step.

This is the root cause of #137 ("SMS token page keeps refreshing"), and I can
confirm it affects the **app-approval** flow identically, not just SMS/OTP -
the bug is in the polling mechanism itself, not the verification method.

## The fix

Two changes, both reusing the existing `replaceHostsBack()` helper (which
today is only ever applied to the `Referer` header on POST requests):

1. `rewriteProxyPath()` now also un-rewrites proxy-prefixed URLs embedded in
   the outgoing request's **query string**, before the request is
   constructed. This has to happen in `pathRewrite`, not in `onProxyReq` -
   mutating `proxyReq.path` later has no effect, since Node has already
   written the request line to the socket by the time `onProxyReq` fires.
2. `application/x-www-form-urlencoded` **POST bodies** are now fully
   buffered and parsed by a small middleware mounted before the proxy
   middleware, so `onProxyReq` can fix embedded proxy URLs in form fields the
   same way and re-send the (possibly modified) body itself. This has to be
   a separate middleware ahead of the proxy for the same reason: once
   `onProxyReq` fires, http-proxy has already started piping the original
   (unmodified) request stream through, so buffering has to complete first.

I intentionally avoided `express.urlencoded()` / `http-proxy-middleware`'s
`fixRequestBody()` helper for the body handling - the existing test harness
(`test/proxy-cookie-rewrite.test.js` etc.) loads `lib/proxy.js` in a `vm`
sandbox with minimal `express`/`http-proxy-middleware` stubs that don't
implement either, and the manual version only needs `querystring`, already a
dependency of this file.

## Testing

- Reproduced the bug live against a real `amazon.it` account (SMS delivery
  blocked, used the "send via WhatsApp" OTP fallback + the app-approval
  flow) - both hung in the reload loop against `master`, both completed with
  a valid `refreshToken` with this patch applied.
- `node test/run-tests.js` - all 9 existing test files pass unchanged.

Fixes #137.