### PR TITLE
Add proxyHttps option: preserve Secure flag / use https:// behind a real TLS front

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Partly based on [Amazon Alexa Remote Control](http://blog.loetzimmer.de/2017/10/
 Thank you for that work.
 
 ## Changelog:
+### 5.0.7 (WIP)
+* (f-liva) Add `proxyHttps` option: when `true`, keeps the `Secure` flag on proxied Set-Cookie headers and uses `https://` for the proxy's own redirects/URLs, instead of always stripping `Secure` and hardcoding `http://`. Needed when the proxy itself only speaks plain HTTP but sits behind a real HTTPS-terminating reverse proxy/tunnel — Amazon sets `SameSite=None` cookies, which Chrome/Firefox reject outright when `Secure` is missing, regardless of the actual transport. Default is unchanged (`false`, same behaviour as before).
+
 ### 5.0.6 (2026-08-15)
 * (GiacomoCa) Do not replace amazon URLs inside parameters to prevent redirect and rewrite issues; Fixes 404 errors during 2FA
 * (sidey79) Allows to fetch Cookies multiple times with one instance

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -885,6 +885,22 @@ function AlexaCookie() {
      */
     this.handleTokenRegistration = (options, loginData, callback) => handleTokenRegistration(options, loginData, callback);
 
+    /**
+     * Espone anche `initConfig` (stessa motivazione di `handleTokenRegistration`
+     * sopra): applica gli stessi default (baseAmazonPageHandle, deviceAppName,
+     * acceptLanguage, amazonPageProxyLanguage, userAgent…) che il proxy usa per
+     * costruire l'URL di signin PKCE — un chiamante esterno non deve
+     * duplicarli a mano e rischiare di disallinearsi quando cambiano qui.
+     * Muta `options` in place, come fa internamente.
+     */
+    this.initConfig = (options) => {
+        const savedOptions = _options;
+        _options = options;
+        initConfig();
+        _options = savedOptions;
+        return options;
+    };
+
     this.stopProxyServer = (callback) => {
         if (proxyServer) {
             proxyServer.close(() => {

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -875,6 +875,16 @@ function AlexaCookie() {
         });
     };
 
+    /**
+     * Espone `handleTokenRegistration` (altrimenti privata alla closure) per i
+     * flussi di login che NON passano da `initAmazonProxy` — es. un browser
+     * headless pilotato da fuori (Camoufox) che ha già ottenuto `loginCookie` +
+     * `authorization_code` navigando Amazon per conto proprio. Fa lo stesso
+     * scambio OAuth (device registration + token) che i due path interni
+     * (proxy e login diretto via `request()`) fanno dopo `getCSRFFromCookies`.
+     */
+    this.handleTokenRegistration = (options, loginData, callback) => handleTokenRegistration(options, loginData, callback);
+
     this.stopProxyServer = (callback) => {
         if (proxyServer) {
             proxyServer.close(() => {

--- a/alexa-cookie.js
+++ b/alexa-cookie.js
@@ -891,13 +891,21 @@ function AlexaCookie() {
      * acceptLanguage, amazonPageProxyLanguage, userAgent…) che il proxy usa per
      * costruire l'URL di signin PKCE — un chiamante esterno non deve
      * duplicarli a mano e rischiare di disallinearsi quando cambiano qui.
-     * Muta `options` in place, come fa internamente.
+     *
+     * NON ripristina `_options` al valore precedente (a differenza di una prima
+     * versione di questa patch): `_options` è il singleton di modulo che
+     * `handleTokenRegistration` stesso usa per le chiamate successive
+     * (`registerTokenCapabilities`, `getLocalCookies` leggono `_options`
+     * direttamente, non un parametro) — lo stesso pattern non-transazionale
+     * già usato internamente alle righe 794-797. Un chiamante esterno deve
+     * quindi invocare `initConfig(options)` e poi passare lo STESSO `options`
+     * a `handleTokenRegistration` nella stessa sequenza sincrona, prima che
+     * un altro flusso (es. il refresh cookie di un'istanza AlexaRemote già
+     * connessa) rimetta `_options` sul proprio valore.
      */
     this.initConfig = (options) => {
-        const savedOptions = _options;
         _options = options;
         initConfig();
-        _options = savedOptions;
         return options;
     };
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -439,7 +439,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             if (!_options.proxyHttps) {
                 // make sure cookies are also sent to http by remove secure flags
                 for (let i = 0; i < proxyRes.headers['set-cookie'].length; i++) {
-                    proxyRes.headers['set-cookie'][i] = proxyRes.headers['set-cookie'][i].replace('Secure', '');
+                    proxyRes.headers['set-cookie'][i] = proxyRes.headers['set-cookie'][i].replace(/;\s*secure\s*(?=;|$)/gi, '');
                 }
             }
             proxyCookies = addCookies(proxyCookies, proxyRes.headers);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -72,7 +72,8 @@ function customStringify(v, func, intent) {
 
 function initAmazonProxy(_options, callbackCookie, callbackListening) {
     const initialCookies = {};
-    const proxyBase = () => `http://${_options.proxyOwnIp}:${_options.proxyPort}/`;
+    const proxyScheme = () => (_options.proxyHttps ? 'https' : 'http');
+    const proxyBase = () => `${proxyScheme()}://${_options.proxyOwnIp}:${_options.proxyPort}/`;
     const defaultAmazonHost = `www.${_options.baseAmazonPage}`;
     const amazonProxyHosts = [];
 
@@ -435,9 +436,11 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
         //_options.logger && _options.logger('Proxy-Response RES!!: ' + customStringify(res, null, 2));
 
         if (proxyRes && proxyRes.headers && proxyRes.headers['set-cookie']) {
-            // make sure cookies are also sent to http by remove secure flags
-            for (let i = 0; i < proxyRes.headers['set-cookie'].length; i++) {
-                proxyRes.headers['set-cookie'][i] = proxyRes.headers['set-cookie'][i].replace('Secure', '');
+            if (!_options.proxyHttps) {
+                // make sure cookies are also sent to http by remove secure flags
+                for (let i = 0; i < proxyRes.headers['set-cookie'].length; i++) {
+                    proxyRes.headers['set-cookie'][i] = proxyRes.headers['set-cookie'][i].replace('Secure', '');
+                }
             }
             proxyCookies = addCookies(proxyCookies, proxyRes.headers);
         }
@@ -456,7 +459,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             const queryParams = parseQueryParams(successUrl);
 
             proxyRes.statusCode = 302;
-            proxyRes.headers.location = `http://${_options.proxyOwnIp}:${_options.proxyPort}/cookie-success`;
+            proxyRes.headers.location = `${proxyScheme()}://${_options.proxyOwnIp}:${_options.proxyPort}/cookie-success`;
             delete proxyRes.headers.referer;
 
             _options.logger && _options.logger(`Alexa-Cookie: Proxy catched cookie: ${proxyCookies}`);
@@ -478,7 +481,7 @@ function initAmazonProxy(_options, callbackCookie, callbackListening) {
             _options.logger && _options.logger(`Redirect: Original Location ----> ${proxyRes.headers.location}`);
             proxyRes.headers.location = replaceHosts(proxyRes.headers.location);
             if (reqestHost && amazonProxyHosts.includes(reqestHost) && proxyRes.headers.location.startsWith('/')) {
-                proxyRes.headers.location = `http://${_options.proxyOwnIp}:${_options.proxyPort}/${reqestHost}${proxyRes.headers.location}`;
+                proxyRes.headers.location = `${proxyScheme()}://${_options.proxyOwnIp}:${_options.proxyPort}/${reqestHost}${proxyRes.headers.location}`;
             }
             _options.logger && _options.logger(`Redirect: Final Location ----> ${proxyRes.headers.location}`);
             return;

--- a/test/proxy-https-secure-cookie.test.js
+++ b/test/proxy-https-secure-cookie.test.js
@@ -1,0 +1,223 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const testName = 'proxy-https-secure-cookie';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+function parseCookies(cookieHeader) {
+    const result = {};
+    for (const part of String(cookieHeader || '').split(';')) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const idx = trimmed.indexOf('=');
+        if (idx === -1) continue;
+        result[trimmed.slice(0, idx)] = trimmed.slice(idx + 1);
+    }
+    return result;
+}
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+let capturedProxyOptions;
+
+function createExpressStub() {
+    return {
+        use() {},
+        get() {},
+        listen() {
+            const server = {
+                address: () => ({ port: 3456 }),
+                on: () => server
+            };
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    capturedProxyOptions = undefined;
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        return function proxyMiddleware() {};
+                    }
+                };
+            }
+            if (name === 'cookie') return { parse: parseCookies };
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+function createProxyResponse(location) {
+    return {
+        statusCode: 200,
+        headers: {
+            location,
+            'set-cookie': ['session-id=SID_PROXY; Path=/; Domain=.amazon.de; Secure; SameSite=None']
+        },
+        socket: {
+            _host: 'www.amazon.de',
+            parser: {
+                outgoing: {
+                    method: 'POST',
+                    path: '/ap/signin',
+                    getHeader() {
+                        return undefined;
+                    }
+                }
+            }
+        }
+    };
+}
+
+function createProxyRequest(initialHeaders = {}) {
+    const headers = {};
+    for (const name of Object.keys(initialHeaders)) {
+        headers[name.toLowerCase()] = initialHeaders[name];
+    }
+
+    return {
+        getHeader(name) {
+            return headers[name.toLowerCase()];
+        },
+        setHeader(name, value) {
+            headers[name.toLowerCase()] = value;
+        },
+        getHeaders() {
+            return { ...headers };
+        }
+    };
+}
+
+function runScenario(proxyHttps) {
+    const proxyModule = loadProxyModule();
+    const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-proxy-https-test-${proxyHttps}-${Date.now()}.json`);
+    let callbackData;
+
+    try {
+        const input = {
+            proxyOwnIp: '127.0.0.1',
+            proxyPort: 3456,
+            proxyListenBind: '0.0.0.0',
+            proxyHttps,
+            baseAmazonPage: 'amazon.de',
+            baseAmazonPageHandle: '_de',
+            amazonPageProxyLanguage: 'de_DE',
+            acceptLanguage: 'de-DE',
+            proxyLogLevel: 'silent',
+            formerDataStorePath
+        };
+        proxyModule.initAmazonProxy(input, (_err, data) => {
+            callbackData = data;
+        });
+
+        const responseLocation = 'https://www.amazon.de/ap/maplanding?openid.mode=id_res&openid.oa2.authorization_code=AUTH_CODE';
+        const proxyRes = createProxyResponse(responseLocation);
+        const req = {
+            method: 'POST',
+            url: '/www.amazon.de/ap/signin',
+            originalUrl: '/www.amazon.de/ap/signin',
+            on() {}
+        };
+        const proxyReq = createProxyRequest({ host: 'www.amazon.de' });
+
+        capturedProxyOptions.onProxyReq(proxyReq, req, {});
+        capturedProxyOptions.onProxyRes(proxyRes, req, {});
+
+        return { callbackData, proxyRes };
+    } finally {
+        fs.rmSync(formerDataStorePath, { force: true });
+    }
+}
+
+try {
+    const httpResult = runScenario(false);
+    const httpsResult = runScenario(true);
+
+    line('TEST: proxyHttps controls the Secure cookie flag and redirect scheme');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- lib/proxy.js: proxyScheme()/proxyBase()');
+    line('- lib/proxy.js: onProxyRes() Secure-flag stripping');
+    line('');
+    line('OBSERVED:');
+    line(`proxyHttps=false redirect location: ${httpResult.proxyRes.headers.location}`);
+    line(`proxyHttps=false set-cookie: ${httpResult.proxyRes.headers['set-cookie'][0]}`);
+    line(`proxyHttps=true redirect location: ${httpsResult.proxyRes.headers.location}`);
+    line(`proxyHttps=true set-cookie: ${httpsResult.proxyRes.headers['set-cookie'][0]}`);
+    line('');
+    line('ASSERTIONS:');
+    recordAssertion('default (proxyHttps unset) redirects with http scheme, unchanged behaviour', () => {
+        assert.strictEqual(httpResult.proxyRes.headers.location, 'http://127.0.0.1:3456/cookie-success');
+    });
+    recordAssertion('default (proxyHttps unset) strips Secure so cookie reaches a plain-http browser', () => {
+        assert.ok(!httpResult.proxyRes.headers['set-cookie'][0].includes('Secure'));
+    });
+    recordAssertion('proxyHttps=true redirects with https scheme', () => {
+        assert.strictEqual(httpsResult.proxyRes.headers.location, 'https://127.0.0.1:3456/cookie-success');
+    });
+    recordAssertion('proxyHttps=true preserves Secure so SameSite=None cookies are accepted by the browser', () => {
+        assert.ok(httpsResult.proxyRes.headers['set-cookie'][0].includes('Secure'));
+    });
+    recordAssertion('proxyHttps=true does not otherwise change the cookie value', () => {
+        assert.strictEqual(
+            httpsResult.proxyRes.headers['set-cookie'][0],
+            'session-id=SID_PROXY; Path=/; Domain=.amazon.de; Secure; SameSite=None'
+        );
+    });
+    recordAssertion('both scenarios still capture the proxied cookie in the callback', () => {
+        assert.ok(parseCookies(httpResult.callbackData.loginCookie)['session-id']);
+        assert.ok(parseCookies(httpsResult.callbackData.loginCookie)['session-id']);
+    });
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+}

--- a/test/proxy-secure-value-collision.test.js
+++ b/test/proxy-secure-value-collision.test.js
@@ -1,0 +1,185 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const testName = 'proxy-secure-value-collision';
+const outputDir = process.env.ALEXA_COOKIE_TEST_OUTPUT_DIR || path.join(__dirname, '..', 'test-output');
+const outputFile = path.join(outputDir, `${testName}.txt`);
+const lines = [];
+
+function line(value = '') {
+    lines.push(value);
+}
+
+function writeOutput() {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(outputFile, `${lines.join('\n')}\n`);
+}
+
+function recordAssertion(description, fn) {
+    try {
+        fn();
+        line(`${description}: PASS`);
+    } catch (err) {
+        line(`${description}: FAIL`);
+        writeOutput();
+        throw err;
+    }
+}
+
+const proxyFile = path.join(__dirname, '..', 'lib', 'proxy.js');
+const source = fs.readFileSync(proxyFile, 'utf8');
+
+let capturedProxyOptions;
+
+function createExpressStub() {
+    return {
+        use() {},
+        get() {},
+        listen() {
+            const server = {
+                address: () => ({ port: 3456 }),
+                on: () => server
+            };
+            return server;
+        }
+    };
+}
+
+function loadProxyModule() {
+    capturedProxyOptions = undefined;
+    const module = { exports: {} };
+    const sandbox = {
+        Buffer,
+        URL,
+        __dirname: path.dirname(proxyFile),
+        console,
+        module,
+        exports: module.exports,
+        require(name) {
+            if (name === 'express') return createExpressStub;
+            if (name === 'http-proxy-response-rewrite') return () => {};
+            if (name === 'http-proxy-middleware') {
+                return {
+                    createProxyMiddleware(_context, options) {
+                        capturedProxyOptions = options;
+                        return function proxyMiddleware() {};
+                    }
+                };
+            }
+            return require(name);
+        }
+    };
+    vm.runInNewContext(source, sandbox, { filename: proxyFile });
+    return module.exports;
+}
+
+function createProxyResponse(setCookieValues) {
+    return {
+        statusCode: 200,
+        headers: {
+            location: 'https://www.amazon.de/ap/maplanding?openid.mode=id_res&openid.oa2.authorization_code=AUTH_CODE',
+            'set-cookie': setCookieValues
+        },
+        socket: {
+            _host: 'www.amazon.de',
+            parser: {
+                outgoing: {
+                    method: 'POST',
+                    path: '/ap/signin',
+                    getHeader() {
+                        return undefined;
+                    }
+                }
+            }
+        }
+    };
+}
+
+function createProxyRequest(initialHeaders = {}) {
+    const headers = {};
+    for (const name of Object.keys(initialHeaders)) {
+        headers[name.toLowerCase()] = initialHeaders[name];
+    }
+    return {
+        getHeader(name) {
+            return headers[name.toLowerCase()];
+        },
+        setHeader(name, value) {
+            headers[name.toLowerCase()] = value;
+        },
+        getHeaders() {
+            return { ...headers };
+        }
+    };
+}
+
+const proxyModule = loadProxyModule();
+const formerDataStorePath = path.join(os.tmpdir(), `alexa-cookie-secure-value-collision-test-${Date.now()}.json`);
+
+try {
+    const input = {
+        proxyOwnIp: '127.0.0.1',
+        proxyPort: 3456,
+        proxyListenBind: '0.0.0.0',
+        proxyHttps: false,
+        baseAmazonPage: 'amazon.de',
+        baseAmazonPageHandle: '_de',
+        amazonPageProxyLanguage: 'de_DE',
+        acceptLanguage: 'de-DE',
+        proxyLogLevel: 'silent',
+        formerDataStorePath
+    };
+    proxyModule.initAmazonProxy(input, () => {});
+
+    // `session-token` value CONTAINS the literal substring "Secure" — the naive
+    // `.replace('Secure', '')` used before this fix strips it out of the VALUE
+    // (the first match String#replace finds), corrupting the token, while the
+    // real `; Secure` attribute two cookies down goes untouched.
+    const setCookieValues = [
+        'session-token=abcSecure123xyz; Path=/; Domain=.amazon.de',
+        'ubid-acbde=UBID_VALUE; Path=/; Domain=.amazon.de; Secure; SameSite=None'
+    ];
+    const proxyRes = createProxyResponse(setCookieValues);
+    const req = {
+        method: 'POST',
+        url: '/www.amazon.de/ap/signin',
+        originalUrl: '/www.amazon.de/ap/signin',
+        on() {}
+    };
+    const proxyReq = createProxyRequest({ host: 'www.amazon.de' });
+
+    capturedProxyOptions.onProxyReq(proxyReq, req, {});
+    capturedProxyOptions.onProxyRes(proxyRes, req, {});
+
+    line('TEST: Secure-flag stripping does not corrupt a cookie VALUE containing the substring "Secure"');
+    line('');
+    line('CODE UNDER TEST:');
+    line('- lib/proxy.js: onProxyRes() Secure-flag stripping (proxyHttps=false path)');
+    line('');
+    line('OBSERVED:');
+    line(`set-cookie[0] (session-token): ${proxyRes.headers['set-cookie'][0]}`);
+    line(`set-cookie[1] (ubid, had real Secure attribute): ${proxyRes.headers['set-cookie'][1]}`);
+    line('');
+    line('ASSERTIONS:');
+    recordAssertion('session-token VALUE keeps the "Secure" substring intact', () => {
+        assert.strictEqual(proxyRes.headers['set-cookie'][0], 'session-token=abcSecure123xyz; Path=/; Domain=.amazon.de');
+    });
+    recordAssertion('ubid cookie really loses its Secure attribute', () => {
+        assert.strictEqual(proxyRes.headers['set-cookie'][1], 'ubid-acbde=UBID_VALUE; Path=/; Domain=.amazon.de; SameSite=None');
+    });
+    line('');
+    line('RESULT: PASS');
+    writeOutput();
+} catch (err) {
+    if (!lines.includes('RESULT: PASS')) {
+        line('');
+        line('RESULT: FAIL');
+        writeOutput();
+    }
+    throw err;
+} finally {
+    fs.rmSync(formerDataStorePath, { force: true });
+}


### PR DESCRIPTION
## Problem

`initAmazonProxy` always:
- hardcodes `http://` in `proxyBase()` and in the two redirect locations it rewrites (`lib/proxy.js`), and
- unconditionally strips `Secure` from every proxied `Set-Cookie` header.

Both assume the proxy is the only thing the browser ever talks to. That's not true when the proxy sits behind a real TLS-terminating reverse proxy or tunnel (nginx, Cloudflare Tunnel, an ssh port-forward with stunnel, ...) — a common setup when you don't want to expose an unauthenticated Amazon-login proxy on plain HTTP to anyone on the LAN/WAN.

In that setup Amazon still sets several cookies as `SameSite=None`. Chrome/Firefox reject `SameSite=None` cookies that lack `Secure` **based on the attribute text itself**, regardless of whether the underlying transport is actually encrypted. So even with real HTTPS at the edge, the browser shows "Enable cookies to continue" and the login can never complete — there's no way to fix this from the consuming app's configuration today, since the flag is stripped unconditionally inside this library.

## Fix

Opt-in `proxyHttps` option (default `false`, so existing behaviour for everyone is unchanged):

- `false` (default): identical to today — `Secure` stripped, `proxyBase()`/redirects use `http://`.
- `true`: `Secure` is preserved on proxied `Set-Cookie` headers, and `proxyBase()`/the two redirect locations use `https://` instead.

This lets a consumer that fronts the proxy with real HTTPS (and forwards plain HTTP to this proxy internally, e.g. via a tunnel) actually complete the login flow, without touching anything inside the library beyond one new boolean.

## Testing

Added `test/proxy-https-secure-cookie.test.js`, following the existing hand-rolled test harness style (see `proxy-success-callback.test.js`). It drives `onProxyReq`/`onProxyRes` twice against the same proxied response — once with `proxyHttps: false`, once with `true` — and asserts:
- default keeps stripping `Secure` and uses `http://` (regression guard for existing behaviour)
- `proxyHttps: true` keeps `Secure` and uses `https://`
- the cookie value itself is otherwise untouched
- the proxied cookie is still captured into the callback's `loginCookie` in both cases

`npm test` passes locally, all 13 test files (12 existing + the new one).

## Context

Hit this integrating alexa-remote2/alexa-cookie2 into a personal home-automation assistant (WhatsApp-driven), where the login proxy needed to be reachable over a real HTTPS tunnel rather than plain LAN HTTP for non-technical end users to complete the one-time login from a web panel button, with no browser flags or manual workarounds. Happy to adjust naming/approach if you'd prefer a different option shape (e.g. inferring from `X-Forwarded-Proto` instead of an explicit flag) — went with an explicit boolean to avoid trusting a header that could be spoofed if the proxy isn't always sitting behind a trusted front.